### PR TITLE
feat: animate globe

### DIFF
--- a/src/lib/components/GlobeMapSVG.svelte
+++ b/src/lib/components/GlobeMapSVG.svelte
@@ -63,8 +63,14 @@
 
   // Clean up the font loading effect when the component is destroyed
   onDestroy(() => {
-    if (animationFrame) cancelAnimationFrame(animationFrame);
-    if (inactivityTimeout) clearTimeout(inactivityTimeout);
+    if (animationFrame) {
+      cancelAnimationFrame(animationFrame);
+      animationFrame = null;
+    }
+    if (inactivityTimeout) {
+      clearTimeout(inactivityTimeout);
+      inactivityTimeout = null;
+    }
     componentActive = false;
   });
 


### PR DESCRIPTION
This pull request introduces an auto-rotation feature to the `GlobeMapSVG` component, enhancing its interactivity and user experience. Key changes include the addition of auto-rotation functionality, management of inactivity timeouts, and cleanup of resources when the component is destroyed.

### Auto-Rotation Functionality:
* Added a new `autoRotating` state and `rotationSpeed` constant to control the globe's rotation. The globe now rotates automatically when the user is not interacting with it. (`src/lib/components/GlobeMapSVG.svelte`, [src/lib/components/GlobeMapSVG.svelteR34-R52](diffhunk://#diff-abad51e9026df1503bcba5464ec396c136395052ae1b619086c7c683e311803dR34-R52))
* Implemented the `animateGlobe` function to update the globe's rotation frame by frame using `requestAnimationFrame`. (`src/lib/components/GlobeMapSVG.svelte`, [src/lib/components/GlobeMapSVG.svelteR34-R52](diffhunk://#diff-abad51e9026df1503bcba5464ec396c136395052ae1b619086c7c683e311803dR34-R52))

### Inactivity Timeout Management:
* Introduced an `inactivityTimeout` state to detect periods of user inactivity. The globe resumes auto-rotation after a delay (`inactivityDelay`) when the user stops interacting. (`src/lib/components/GlobeMapSVG.svelte`, [[1]](diffhunk://#diff-abad51e9026df1503bcba5464ec396c136395052ae1b619086c7c683e311803dR151-R155) [[2]](diffhunk://#diff-abad51e9026df1503bcba5464ec396c136395052ae1b619086c7c683e311803dR184-R188)
* Ensured that the auto-rotation state is paused during user interactions (e.g., dragging) and reset after inactivity. (`src/lib/components/GlobeMapSVG.svelte`, [[1]](diffhunk://#diff-abad51e9026df1503bcba5464ec396c136395052ae1b619086c7c683e311803dR141) [[2]](diffhunk://#diff-abad51e9026df1503bcba5464ec396c136395052ae1b619086c7c683e311803dR172)

### Resource Cleanup:
* Added logic to clean up animation frames and inactivity timeouts when the component is destroyed to prevent memory leaks. (`src/lib/components/GlobeMapSVG.svelte`, [src/lib/components/GlobeMapSVG.svelteR66-R67](diffhunk://#diff-abad51e9026df1503bcba5464ec396c136395052ae1b619086c7c683e311803dR66-R67))