### PR TITLE
ci: fix env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           touch .env
           echo "VITE_RPC_PROXY_TARGET=${{ secrets.VITE_RPC_PROXY_TARGET }}" >> .env
+          echo "NETWORK=${{ vars.NETWORK }}" >> .env
 
       - name: Build application
         run: bun run build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           touch .env
           echo "VITE_RPC_PROXY_TARGET=${{ secrets.VITE_RPC_PROXY_TARGET }}" >> .env
+          echo "NETWORK=${{ vars.NETWORK }}" >> .env
           cat .env
 
       - name: Get the Git tag


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to include a new environment variable, `NETWORK`, in the `.env` file during the build process. This change ensures that the `NETWORK` variable is consistently available across workflows.

Updates to GitHub Actions workflows:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R31): Added the `NETWORK` variable to the `.env` file in the `build` job.
* [`.github/workflows/docker.yml`](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94R34): Added the `NETWORK` variable to the `.env` file in the `docker` job.