### PR TITLE
fix: market cap vs supply

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -35,14 +35,13 @@
   const chainMetrics: PartialBetaChainMetric = $derived(data.latestChainMetric)
   const cumsumMetrics: PartialCumsumMetric = $derived(data.latestCumsumMetric);
   const geoData: GeoRecordArray = $derived(data.worldMap)
-
-  // Divide the total supply by the number of decimal places (6) to get the actual token amount
-  const totalSupply: BigNumber = $derived(BigNumber(chainMetrics.manifest_tokenomics_total_supply).div(1_000_000))
+  const totalSupply: BigNumber = $derived(BigNumber(chainMetrics.manifest_tokenomics_total_supply))
 
   // Convert the MANY PWR:MFX conversion rate to Manifest by dividing by the 1:10 split
   const pwrMfx: BigNumber = $derived(BigNumber(metrics.talib_mfx_power_conversion ?? "1").div(10));
 
-  const estimatedMarketCap: BigNumber = $derived(BigNumber(totalSupply).multipliedBy(pwrMfx));
+  // Divide the total supply by the number of decimal places (6) to get the actual token amount
+  const estimatedMarketCap: BigNumber = $derived(totalSupply.div(1_000_000).multipliedBy(pwrMfx));
   const uniqueCountries: number = $derived(
     new Set(geoData.map(item => item.country_name)).size
   );


### PR DESCRIPTION
This pull request refactors the calculation of `totalSupply` and `estimatedMarketCap` in the `src/routes/+page.svelte` file to improve clarity and correctness. The most important changes include moving the division of `totalSupply` by decimal places from its initialization to its usage in the calculation of `estimatedMarketCap`.

### Refactoring of tokenomics calculations:

* [`src/routes/+page.svelte`](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL38-R44): Removed the division of `totalSupply` by `1_000_000` during its initialization and instead applied this division directly in the calculation of `estimatedMarketCap`. This ensures the raw `totalSupply` value is preserved for potential reuse elsewhere.