### PR TITLE
chore: refactor for dry

### DIFF
--- a/src/lib/loaders/loadAggregateMetric.ts
+++ b/src/lib/loaders/loadAggregateMetric.ts
@@ -1,5 +1,5 @@
 import {createDataLoader} from "./createDataLoader";
 
 export function loadAggregateMetric(ids: string[]) {
-  return createDataLoader(ids, (id, params) => `/rpc/get_agg_${id}?${params.toString()}`);
+  return createDataLoader(ids, (id, params) => `/rpc/get_common_agg_${id}?${params.toString()}`);
 }

--- a/src/lib/loaders/loadCumsumMetric.ts
+++ b/src/lib/loaders/loadCumsumMetric.ts
@@ -2,6 +2,6 @@ import {createDataLoader} from "./createDataLoader";
 
 export function loadCumsumMetric(ids: string[]) {
   return createDataLoader(ids, (id, params) =>
-    `/rpc/get_cumsum_${id}?${params.toString()}`
+    `/rpc/get_cumsum_agg_${id}?${params.toString()}`
   );
 }


### PR DESCRIPTION
This pull request updates the endpoint URLs in two metric loader functions to align with new naming conventions for aggregated metrics.

Endpoint updates for metric loaders:

* [`src/lib/loaders/loadAggregateMetric.ts`](diffhunk://#diff-373d1334ba23788348cc422656fb2c95567ff2a666ae89fe97002a937681ee34L4-R4): Updated the endpoint from `/rpc/get_agg_${id}` to `/rpc/get_common_agg_${id}` to reflect the new naming convention for aggregate metrics.
* [`src/lib/loaders/loadCumsumMetric.ts`](diffhunk://#diff-8eb88fae197fe52da8693c0a9ef42f9e345425f02cf1ac138db2b912124c0275L5-R5): Updated the endpoint from `/rpc/get_cumsum_${id}` to `/rpc/get_cumsum_agg_${id}` to reflect the new naming convention for cumulative sum metrics.