### PR TITLE
feat: continuous circulating supply

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,7 +3,7 @@ type ChartCategory = 'network' | 'minio' | 'kube' | 'blockchain' | 'dn' | 'gc' |
 type ChartTitle = string | ((latest?: ChartDataPoint) => string);
 type TimeScale = '10 seconds' | '1 minute' | '1 hour' | '1 day' | '1 week' | '1 month' | '3 months' | '1 year';
 type TimeSpan = '1 hour' | '1 day' | '1 week' | '1 month' | '3 months' | '1 year'
-type ChartType = 'common' | 'chain' | 'cumsum'
+type ChartType = 'common' | 'chain' | 'cumsum' | 'supply'
 
 interface ChartConfig {
   id: string;

--- a/src/lib/loaders/loadAggregateSupplyMetrics.ts
+++ b/src/lib/loaders/loadAggregateSupplyMetrics.ts
@@ -1,0 +1,5 @@
+import {createDataLoader} from "./createDataLoader";
+
+export function loadAggregateSupplyMetric(network: string, ids: string[]) {
+  return createDataLoader(ids, (id, params) => `/rpc/get_${network}_${id}?${params.toString()}`);
+}

--- a/src/lib/loaders/loadLatestSupplyMetrics.ts
+++ b/src/lib/loaders/loadLatestSupplyMetrics.ts
@@ -1,0 +1,9 @@
+import {createSingleLoader} from "./createDataLoader";
+import {SingleMetricValueSchema} from "$lib/schemas/metricRecord";
+
+export function loadLatestSupplyMetric(network: NetworkType, id: string) {
+  return createSingleLoader(
+    () => `/api/latest_${network}_${id}`,
+    SingleMetricValueSchema
+  );
+}

--- a/src/lib/schemas/charts.ts
+++ b/src/lib/schemas/charts.ts
@@ -19,14 +19,10 @@ export const ChartDataPointArraySchema = (group: string) => {
     arr.map((r) => {
       const date = new Date(r.timestamp);
 
-      // By now, if this is the “total_supply” metric, r.tags.supply holds the adjusted value.
-      // Otherwise, r.value is the adjusted value.
-      const rawValue = r.tags?.supply ? r.tags.supply : r.value;
-
       return ChartDataPointSchema.parse({
         group,
         key: date.toISOString(),
-        value: rawValue,
+        value: r.value,
         date,
       });
     })

--- a/src/lib/schemas/metricRecord.ts
+++ b/src/lib/schemas/metricRecord.ts
@@ -21,6 +21,17 @@ export const MetricRecordSchema = z.object({
   value: bigNumberLike,
 })
 
+export const MetricRecordArraySchema = z.array(MetricRecordSchema)
+
+export const SingleMetricValueSchema = MetricRecordArraySchema.transform(
+  (arr) => {
+    if (arr.length !== 1) {
+      throw new Error(`Expected array of length 1, got ${arr.length}`)
+    }
+    return arr[0].value
+  }
+)
+
 // All metric preprocessing happens here. Includes adjustments for
 // - Mainnet offsets and launch date
 // - Special cases where the value is stored in the tags object

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -4,14 +4,16 @@ import {loadLatestMetric} from "$lib/loaders/loadLatestMetric";
 import {loadLatestChainMetric} from "$lib/loaders/loadLatestChainMetric";
 import {loadLatestCumsumMetric} from "$lib/loaders/loadLatestCumsumMetrics";
 import { NETWORK } from '$env/static/private';
+import { loadLatestSupplyMetric } from "$lib/loaders/loadLatestSupplyMetrics";
 
 export const load: PageServerLoad = async (event) => {
   const network = NETWORK as NetworkType;
 
-  const [latestMetric, latestChainMetric, latestCumsumMetric, worldMap] = await Promise.all([
+  const [latestMetric, latestChainMetric, latestCumsumMetric, latestCirculatingSupplyMetric, worldMap] = await Promise.all([
     loadLatestMetric()(event),
     loadLatestChainMetric(network)(event),
     loadLatestCumsumMetric()(event),
+    loadLatestSupplyMetric(network, "circulating_supply")(event),
     loadWorldMapData()(event),
   ]);
 
@@ -19,6 +21,7 @@ export const load: PageServerLoad = async (event) => {
     latestMetric: latestMetric.data,
     latestChainMetric: latestChainMetric.data,
     latestCumsumMetric: latestCumsumMetric.data,
+    latestCirculatingSupplyMetric: latestCirculatingSupplyMetric.data,
     worldMap: worldMap.data,
   };
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -35,9 +35,8 @@
   const chainMetrics: PartialBetaChainMetric = $derived(data.latestChainMetric)
   const cumsumMetrics: PartialCumsumMetric = $derived(data.latestCumsumMetric);
   const geoData: GeoRecordArray = $derived(data.worldMap)
+  const circulatingSupplyMetrics: string = $derived(data.latestCirculatingSupplyMetric)
   const totalSupply: BigNumber = $derived(BigNumber(chainMetrics.manifest_tokenomics_total_supply))
-  const excludedSupply: BigNumber = $derived(BigNumber(chainMetrics.manifest_tokenomics_excluded_supply))
-  const circulatingSupply: BigNumber = $derived(totalSupply.minus(excludedSupply));
 
   // Convert the MANY PWR:MFX conversion rate to Manifest by dividing by the 1:10 split
   const pwrMfx: BigNumber = $derived(BigNumber(metrics.talib_mfx_power_conversion ?? "1").div(10));
@@ -78,7 +77,7 @@
               totalBurned={chainMetrics.total_mfx_burned ?? "N/A"}
               pwrMfx={pwrMfx.toFixed()}
               marketCap={estimatedMarketCap ? estimatedMarketCap.toFixed() : "N/A"}
-              circulatingSupply={circulatingSupply ? circulatingSupply.toFixed() : "N/A"}
+              circulatingSupply={circulatingSupplyMetrics}
               lockedTokens={chainMetrics.locked_tokens ?? "N/A"}
       />
 

--- a/src/routes/tokenomic-details/+page.server.ts
+++ b/src/routes/tokenomic-details/+page.server.ts
@@ -3,29 +3,36 @@ import {configs} from "./config";
 import {loadAggregateChainMetric} from "$lib/loaders/loadAggregateChainMetric";
 import {loadAggregateMetric} from "$lib/loaders/loadAggregateMetric";
 import { NETWORK } from '$env/static/private';
+import {loadAggregateSupplyMetric} from "$lib/loaders/loadAggregateSupplyMetrics";
 
 export const load: PageServerLoad = async (event) => {
   const network = NETWORK as NetworkType
 
-  const { chain, common } = configs.reduce(
+  const { chain, common, supply } = configs.reduce(
     (acc, { id, type }) => {
       if (type === 'chain') acc.chain.push(id)
-      else acc.common.push(id)
+      else if (type === 'common') acc.common.push(id)
+      else if (type === 'supply') acc.supply.push(id)
+      else throw new Error(`Unknown type: ${type} for id: ${id}`)
       return acc
     },
-    { chain: [] as string[], common: [] as string[] }
+    { chain: [] as string[], common: [] as string[], supply: [] as string[] }
   )
 
-  const [chainMetric, commonMetric] = await Promise.all([
+  const [chainMetric, commonMetric, circulatingSupply] = await Promise.all([
     loadAggregateChainMetric(network, chain)(event),
-    loadAggregateMetric(common)(event)
+    loadAggregateMetric(common)(event),
+    loadAggregateSupplyMetric(network, supply)(event)
   ]);
 
   const chainData = chainMetric.data;
   const commonData = commonMetric.data;
-  let ai = 0, ci = 0;
+  const supplyData = circulatingSupply.data;
+  let ai = 0, ci = 0, si = 0;
   const data = configs.map(({ type }) =>
-    type === 'chain' ? chainData[ci++] : commonData[ai++]
+    type === 'supply' ? supplyData[si++] :
+      type === 'chain' ? chainData[ci++] :
+        commonData[ai++]
   );
 
 

--- a/src/routes/tokenomic-details/config.ts
+++ b/src/routes/tokenomic-details/config.ts
@@ -37,4 +37,11 @@ export const configs: ChartConfig[] = [
     category: 'tokenomic',
     type: "chain"
   },
+  {
+    id: 'circulating_supply',
+    title: (latest) => `Circulating Supply: ${latest ? formatBaseDenom(latest.value) : "N/A"}`,
+    yAxisTitle: 'Circulating Supply',
+    category: 'tokenomic',
+    type: "supply"
+  },
 ]


### PR DESCRIPTION
This pull request introduces functionality for loading and displaying supply-related metrics, including circulating supply, alongside refactoring and schema updates. The most important changes are the addition of loaders for supply metrics, updates to schemas for consistent data handling, and integration of circulating supply data into the application.

### New loaders for supply metrics:
* Added `loadAggregateSupplyMetric` in `src/lib/loaders/loadAggregateSupplyMetrics.ts` to fetch aggregated supply metrics based on network and IDs.
* Added `loadLatestSupplyMetric` in `src/lib/loaders/loadLatestSupplyMetrics.ts` to fetch the latest supply metric using a network and ID.

### Schema updates:
* Introduced `MetricRecordArraySchema` and `SingleMetricValueSchema` in `src/lib/schemas/metricRecord.ts` to validate and transform metric data, ensuring single-value arrays are handled correctly.
* Simplified the `ChartDataPointArraySchema` in `src/lib/schemas/charts.ts` by removing special handling for `total_supply` metrics and using `r.value` consistently.

### Integration of circulating supply data:
* Updated `src/routes/+page.server.ts` to load and include `latestCirculatingSupplyMetric` in the server-side data fetching logic.
* Modified `src/routes/+page.svelte` to use `latestCirculatingSupplyMetric` directly for displaying circulating supply, replacing the previous manual calculation. [[1]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfR38-L40) [[2]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL81-R80)

### Enhancements to tokenomic details:
* Updated `src/routes/tokenomic-details/+page.server.ts` to handle supply-related configurations and load aggregate supply metrics.
* Added a new configuration for `circulating_supply` in `src/routes/tokenomic-details/config.ts` to display it as part of tokenomic details.