### PR TITLE
fix: only use /rpc

### DIFF
--- a/src/lib/loaders/loadLatestSupplyMetrics.ts
+++ b/src/lib/loaders/loadLatestSupplyMetrics.ts
@@ -3,7 +3,7 @@ import {SingleMetricValueSchema} from "$lib/schemas/metricRecord";
 
 export function loadLatestSupplyMetric(network: NetworkType, id: string) {
   return createSingleLoader(
-    () => `/api/latest_${network}_${id}`,
+    () => `/rpc/get_latest_${network}_${id}`,
     SingleMetricValueSchema
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,11 +11,6 @@ export default defineConfig({
 	},
 	server: {
     proxy: {
-			'/api': {
-				target: proxyTarget,
-				changeOrigin: true,
-				rewrite: (path) => path.replace(/^\/api/, '')
-			},
       '/rpc': proxyTarget
     }
   }


### PR DESCRIPTION
This pull request updates the API endpoint structure and modifies the proxy configuration to align with the new endpoint naming convention. These changes ensure consistency and improve the maintainability of the codebase.

### API Endpoint Updates:
* Updated the API endpoint in `src/lib/loaders/loadLatestSupplyMetrics.ts` to use the `/rpc/get_latest_` prefix instead of `/api/latest_`. (`[src/lib/loaders/loadLatestSupplyMetrics.tsL6-R6](diffhunk://#diff-3df29b18fc26a141752da36d115ec4d9a7caf19034ead8df368efacf19e961e6L6-R6)`)

### Proxy Configuration Changes:
* Removed the proxy configuration for the `/api` endpoint and retained the `/rpc` proxy configuration in `vite.config.ts`. (`[vite.config.tsL14-L18](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL14-L18)`)