### PR TITLE
fix: unknown city/country

### DIFF
--- a/src/lib/schemas/geo.ts
+++ b/src/lib/schemas/geo.ts
@@ -4,8 +4,8 @@ import {z} from "zod/v4";
 const GeoRecordSchema = z.object({
   latitude: z.number(),
   longitude: z.number(),
-  country_name: z.string(),
-  city: z.string(),
+  country_name: z.string().nullish().transform((v) => v ?? "Unknown country"),
+  city: z.string().nullish().transform((v) => v ?? "Unknown city"),
 });
 // An array of geographical records, used for the world map
 export const GeoRecordArraySchema = z.array(GeoRecordSchema);


### PR DESCRIPTION
This pull request updates the `GeoRecordSchema` in `src/lib/schemas/geo.ts` to handle null or undefined values for `country_name` and `city` by providing default values.

Schema updates:

* [`GeoRecordSchema`](diffhunk://#diff-0f6dea7b8fa28e2e14b4a0351248c1482faf65502b59e04875d98b0ca4f50213L7-R8): Modified the `country_name` and `city` fields to allow nullish values and added transformations to default to "Unknown country" and "Unknown city" respectively if no value is provided. (`[src/lib/schemas/geo.tsL7-R8](diffhunk://#diff-0f6dea7b8fa28e2e14b4a0351248c1482faf65502b59e04875d98b0ca4f50213L7-R8)`)