### PR TITLE
feat: button to pause globe rotation

### DIFF
--- a/src/lib/components/GlobeMapSVG.svelte
+++ b/src/lib/components/GlobeMapSVG.svelte
@@ -362,7 +362,8 @@
   </Canvas>
 
   <div class="absolute bottom-4 left-4 z-10 pointer-events-auto group">
-    <button type="button" class="btn preset-outlined-primary-800-200" onclick={handleGlobeRotation}>
+    <button type="button" class="btn preset-outlined-primary-800-200" onclick={handleGlobeRotation}
+            aria-label="Toggle globe rotation">
       {#if autoRotating}
         <Paused size={24}/>
       {:else}
@@ -370,7 +371,8 @@
       {/if}
     </button>
     <!-- Pure CSS tooltip on Canvas -->
-    <div class="tooltip absolute top-full opacity-0 group-hover:opacity-100 group-hover:delay-1000 transition-opacity pointer-events-none delay-0 z-20" style:left="{60}px" style:top="{10}px">
+    <div class="tooltip absolute top-full opacity-0 group-hover:opacity-100 group-hover:delay-1000 transition-opacity pointer-events-none delay-0 z-20"
+         style:left="{60}px" style:top="{10}px">
       <div class="tooltip-content">
         Toggle globe rotation
       </div>


### PR DESCRIPTION
This pull request enhances the `GlobeMapSVG` component by introducing a user interface for toggling globe rotation and improving the rotation logic. The most notable changes include adding a play/pause button with a tooltip, updating the rotation logic to account for manual toggling, and refining the component's styles.

### User Interface Enhancements:
* Added a play/pause button to toggle globe rotation, using `Paused` and `Play` icons from `carbon-icons-svelte`. The button includes a tooltip for user guidance. (`src/lib/components/GlobeMapSVG.svelte`, [[1]](diffhunk://#diff-abad51e9026df1503bcba5464ec396c136395052ae1b619086c7c683e311803dR11-R13) [[2]](diffhunk://#diff-abad51e9026df1503bcba5464ec396c136395052ae1b619086c7c683e311803dR365-R380)

### Rotation Logic Improvements:
* Introduced a new state variable `manuallyDisabledRotation` to differentiate between automatic and manual toggling of rotation. (`src/lib/components/GlobeMapSVG.svelte`, [src/lib/components/GlobeMapSVG.svelteR45](diffhunk://#diff-abad51e9026df1503bcba5464ec396c136395052ae1b619086c7c683e311803dR45))
* Updated rotation logic to respect the `manuallyDisabledRotation` state, ensuring that automatic rotation does not resume if manually disabled. (`src/lib/components/GlobeMapSVG.svelte`, [[1]](diffhunk://#diff-abad51e9026df1503bcba5464ec396c136395052ae1b619086c7c683e311803dL218-R222) [[2]](diffhunk://#diff-abad51e9026df1503bcba5464ec396c136395052ae1b619086c7c683e311803dL251-R255)
* Added a `handleGlobeRotation` function to toggle both `autoRotating` and `manuallyDisabledRotation` states. (`src/lib/components/GlobeMapSVG.svelte`, [src/lib/components/GlobeMapSVG.svelteR285-R289](diffhunk://#diff-abad51e9026df1503bcba5464ec396c136395052ae1b619086c7c683e311803dR285-R289))

### Style Adjustments:
* Updated the `.globe-root` class to include `position: relative`, enabling proper positioning of the new UI elements. (`src/lib/components/GlobeMapSVG.svelte`, [src/lib/components/GlobeMapSVG.svelteR394](diffhunk://#diff-abad51e9026df1503bcba5464ec396c136395052ae1b619086c7c683e311803dR394))