### PR TITLE
fix: null geo data

### DIFF
--- a/src/lib/schemas/geo.ts
+++ b/src/lib/schemas/geo.ts
@@ -1,22 +1,37 @@
 import {z} from "zod/v4";
 
 // A record representing a geographical location as returned by the API
-const GeoRecordSchema = z.object({
+const RawGeoRecordSchema = z.object({
   latitude: z.number().nullish(),
   longitude: z.number().nullish(),
   country_name: z.string().nullish(),
   city: z.string().nullish(),
-}).transform(
-  (item) => {
-    if (item.city === null || item.country_name === null || item.latitude === null || item.longitude === null) {
-      console.warn("Excluding record with null field:", item);
-      return null;
+});
+
+const StrictGeoRecordSchema = z.object({
+  latitude:      z.number(),
+  longitude:     z.number(),
+  country_name:  z.string(),
+  city:          z.string(),
+});
+
+// An array of geographical records, used for the world map
+export const GeoRecordArraySchema = z
+  .array(RawGeoRecordSchema)
+  .transform((records) => {
+    const valid: z.infer<typeof StrictGeoRecordSchema>[] = [];
+
+    for (const record of records) {
+      const result = StrictGeoRecordSchema.safeParse(record);
+      if (!result.success) {
+        console.warn("Excluding record with null field:", record);
+      } else {
+        valid.push(result.data);
+      }
     }
 
-    return item
-  }
-);
-// An array of geographical records, used for the world map
-export const GeoRecordArraySchema = z.array(GeoRecordSchema);
+    return valid;
+  });
+
 export type GeoRecordArray = z.infer<typeof GeoRecordArraySchema>;
-export type GeoRecord = z.infer<typeof GeoRecordSchema>;
+export type GeoRecord = z.infer<typeof StrictGeoRecordSchema>;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -44,7 +44,7 @@
   const tokenMetricsError = $derived(data.latestTokenMetricError);
 
   const uniqueCountries: number = $derived(
-    new Set(geoData.map(item => item?.country_name)).size
+    new Set(geoData.map(item => item?.country_name).filter(Boolean)).size
   );
 </script>
 


### PR DESCRIPTION
This pull request focuses on improving data validation and handling for geographical records, as well as refining the display logic for token metrics on the frontend. The most important changes include updating the `GeoRecordSchema` to exclude invalid records, modifying the calculation of unique countries, and ensuring consistent formatting for numerical values.

### Data validation improvements:

* [`src/lib/schemas/geo.ts`](diffhunk://#diff-0f6dea7b8fa28e2e14b4a0351248c1482faf65502b59e04875d98b0ca4f50213L5-R18): Updated `GeoRecordSchema` to exclude records with null fields by transforming them into `null` and logging a warning. This ensures data integrity for geographical records.

### Frontend display refinements:

* [`src/routes/+page.svelte`](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL47-R47): Modified the calculation of `uniqueCountries` to safely handle potential null values in `geoData` by using optional chaining (`item?.country_name`).
* [`src/routes/+page.svelte`](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL95-R95): Updated the `pwrMfx` calculation to ensure consistent formatting by applying `.toFixed()` to the result of the division. This improves the display of numerical values.