### PR TITLE
fix: locked fees and burned mfx

### DIFF
--- a/src/lib/components/TokenomicsCard.svelte
+++ b/src/lib/components/TokenomicsCard.svelte
@@ -60,7 +60,7 @@
     </div>
     <div>
       <p class="text-xl font-bold text-secondary-400-600">{formatBaseDenom(totalBurned)}</p>
-      <p class="text-xs font-medium text-muted-foreground">Total MFX Burned (incl. fees)</p>
+      <p class="text-xs font-medium text-muted-foreground">Total MFX Burned</p>
     </div>
     <div>
       <p class="text-xl font-bold text-secondary-400-600">{pwrMfx}</p>
@@ -68,11 +68,11 @@
     </div>
     <div>
       <p class="text-xl font-bold text-secondary-400-600">{formatBaseDenom(lockedTokens)}</p>
-      <p class="text-xs font-medium text-muted-foreground">Locked MFX</p>
+      <p class="text-xs font-medium text-muted-foreground">Locked MFX (excl. fees)</p>
     </div>
     <div>
       <p class="text-xl font-bold text-secondary-400-600">{formatBaseDenom(lockedFees)}</p>
-      <p class="text-xs font-medium text-muted-foreground">MFX Fees Spent</p>
+      <p class="text-xs font-medium text-muted-foreground">Locked fees</p>
     </div>
   </div>
 </div>

--- a/src/lib/schemas/betaChainMetrics.ts
+++ b/src/lib/schemas/betaChainMetrics.ts
@@ -5,6 +5,7 @@ import {bigNumberLike} from "$lib/schemas/common";
 // Metrics common to the Manifest Ledger testnet and mainnet.
 export const BetaChainMetricSchema = z.object({
   total_mfx_minted: bigNumberLike.default("0"),
+  total_mfx_burned: bigNumberLike.default("0"),
   total_tx_count: bigNumberLike.default("0"),
   total_unique_user: bigNumberLike.default("0"),
   total_unique_group: bigNumberLike.default("0"),

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -91,7 +91,7 @@
         <TokenomicsCard
                 tokenSupply={chainMetrics.manifest_tokenomics_total_supply ?? "N/A"}
                 totalMinted={chainMetrics.total_mfx_minted ?? "N/A"}
-                totalBurned={tokenMetrics.burned_supply ?? "N/A"}
+                totalBurned={chainMetrics.total_mfx_burned ?? "N/A"}
                 pwrMfx={metrics.talib_mfx_power_conversion ? BigNumber(metrics.talib_mfx_power_conversion).div(10).toFixed() : "N/A"}
                 marketCap={tokenMetrics.market_cap ?? "N/A"}
                 circulatingSupply={tokenMetrics.circulating_supply ?? "N/A"}

--- a/src/routes/tokenomic-details/config.ts
+++ b/src/routes/tokenomic-details/config.ts
@@ -54,14 +54,14 @@ export const configs: ChartConfig[] = [
   {
     id: 'locked_tokens',
     title: (latest) => `Locked MFX: ${latest ? formatBaseDenom(latest.value) : "N/A"}`,
-    yAxisTitle: 'Locked Tokens',
+    yAxisTitle: 'Locked Tokens (excl. fees)',
     category: 'tokenomic',
     type: "chain"
   },
   {
     id: 'locked_fees',
-    title: (latest) => `Burned Fees: ${latest ? formatBaseDenom(latest.value) : "N/A"}`,
-    yAxisTitle: 'Burned Fees',
+    title: (latest) => `Locked Fees: ${latest ? formatBaseDenom(latest.value) : "N/A"}`,
+    yAxisTitle: 'Locked Fees',
     category: 'tokenomic',
     type: "chain"
   },


### PR DESCRIPTION
This pull request updates the terminology and data sources for tokenomics metrics to provide more accurate and consistent information across the UI and backend schema. The main changes include updating labels to clarify fee inclusion/exclusion, switching the data source for burned tokens, and aligning chart titles and axes with the new terminology.

**Tokenomics terminology and data source updates:**

* Changed the label for total burned tokens in `TokenomicsCard.svelte` to "Total MFX Burned" (removing "incl. fees"), and updated "Locked MFX" to indicate "excl. fees". The label for fees was changed from "MFX Fees Spent" to "Locked fees".
* Updated the source of the burned token metric in `+page.svelte` to use `chainMetrics.total_mfx_burned` instead of `tokenMetrics.burned_supply`.
* Added the `total_mfx_burned` field to the `BetaChainMetricSchema` in `betaChainMetrics.ts` for improved backend consistency.

**Chart configuration alignment:**

* Updated chart titles and y-axis labels in `tokenomic-details/config.ts` to clarify fee inclusion/exclusion: "Locked Tokens (excl. fees)" and "Locked Fees" instead of previous terminology.