### PR TITLE
fix: economy ↔ infrastructure

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -56,108 +56,6 @@
 
 <main>
   <div class="max-w-screen mx-auto p-4">
-    <!-- INFRASTRUCTURE -->
-    <Section title="Infrastructure" cols="grid-cols-12">
-      <!-- Decentralized Network -->
-      <div class="col-span-12 md:col-span-6 xl:col-span-3 h-full">
-        {#if metricsError || geoDataError}
-          <ErrorCard title="Decentralized Network" error={metricsError ?? geoDataError}/>
-        {:else}
-          <DecentralizedNetworkCard
-            totalUniqueCountries={uniqueCountries.toFixed() ?? "N/A"}
-            totalNodeCount={metrics.node_count ?? "N/A"}
-            totalCpuCores={metrics.system_cpu_cores ?? "N/A"}
-            totalSystemMemory={metrics.system_memory ?? "N/A"}
-            totalDiskSpace={metrics.disk_space_total ?? "N/A"}
-            totalProcess={metrics.total_process ?? "N/A"}
-            usedDiskSpace={metrics.disk_space_used ?? "N/A"}
-            usedSystemMemory={metrics.system_memory_used ?? "N/A"}
-          />
-        {/if}
-      </div>
-
-      <!-- AI (GPU) -->
-      <div class="col-span-12 md:col-span-6 xl:col-span-3 h-full">
-        {#if metricsError}
-          <ErrorCard title="AI" error={metricsError}/>
-        {:else}
-          <GpuCard
-            totalGpu={metrics.gpu_total ?? "N/A"}
-            totalMemory={metrics.gpu_memory ?? "N/A"}
-            totalNvidiaGpu={metrics.gpu_nvidia_total ?? "N/A"}
-            totalAmdGpu={metrics.gpu_amd_total ?? "N/A"}
-            totalNvidiaMemory={metrics.gpu_nvidia_memory ?? "N/A"}
-            totalAmdMemory={metrics.gpu_amd_memory ?? "N/A"}
-          />
-        {/if}
-      </div>
-
-      <!-- Web Services -->
-      <div class="col-span-12 md:col-span-6 xl:col-span-3 h-full">
-        {#if metricsError || cumsumMetricsError}
-          <ErrorCard title="Web Services" error={metricsError ?? cumsumMetricsError}/>
-        {:else}
-          <WebServiceCard
-            totalWebServer={metrics.web_servers ?? "N/A"}
-            totalRequestPerSec={metrics.web_requests_per_sec ?? "N/A"}
-            totalRequests={cumsumMetrics.web_requests ?? "N/A"}
-          />
-        {/if}
-      </div>
-
-      <!-- Decentralized Websites -->
-      <div class="col-span-12 md:col-span-6 xl:col-span-3 h-full">
-        {#if metricsError || cumsumMetricsError}
-          <ErrorCard title="Decentralized Web Hosting" error={metricsError ?? cumsumMetricsError}/>
-        {:else}
-          <DecentralizedWebHosting
-            totalWebsites={metrics.web_sites ?? "N/A"}
-            totalRequests={cumsumMetrics.decentralized_web_requests ?? "N/A"}
-          />
-        {/if}
-      </div>
-
-      <!-- Kubernetes -->
-      <div class="col-span-12 md:col-span-6 xl:col-span-3 h-full">
-        {#if metricsError}
-          <ErrorCard title="Kubernetes Metrics" error={metricsError}/>
-        {:else}
-          <KubeCard
-            totalNodes={metrics.kube_nodes ?? "N/A"}
-            totalPods={metrics.kube_pods ?? "N/A"}
-            totalMemory={metrics.kube_memory ?? "N/A"}
-          />
-        {/if}
-      </div>
-
-      <!-- Object Storage -->
-      <div class="col-span-12 md:col-span-6 xl:col-span-3 h-full">
-        {#if metricsError}
-          <ErrorCard title="Object Storage" error={metricsError}/>
-        {:else}
-          <ObjectStorageCard
-            totalBuckets={metrics.minio_buckets ?? "N/A"}
-            totalObjects={metrics.minio_total ?? "N/A"}
-            usedStorage={metrics.minio_used ?? "N/A"}
-          />
-        {/if}
-      </div>
-
-      <!-- Network -->
-      <div class="col-span-12 md:col-span-6 xl:col-span-6 h-full">
-        {#if cumsumMetricsError}
-          <ErrorCard title="Network Metrics" error={cumsumMetricsError}/>
-        {:else}
-          <NetworkCard
-            totalIpv4BandwidthReceived={cumsumMetrics.system_network_received ?? "N/A"}
-            totalIpv4BandwidthSent={cumsumMetrics.system_network_sent ?? "N/A"}
-            totalIpv4PacketReceived={cumsumMetrics.system_tcp_received ?? "N/A"}
-            totalIpv4PacketSent={cumsumMetrics.system_tcp_sent ?? "N/A"}
-          />
-        {/if}
-      </div>
-    </Section>
-
     <!-- ECONOMY -->
     <Section title="Economy" cols="grid-cols-12">
       <!-- Tokenomics -->
@@ -196,5 +94,108 @@
         {/if}
       </div>
     </Section>
+
+    <!-- INFRASTRUCTURE -->
+    <Section title="Infrastructure" cols="grid-cols-12">
+      <!-- Decentralized Network -->
+      <div class="col-span-12 md:col-span-6 xl:col-span-3 h-full">
+        {#if metricsError || geoDataError}
+          <ErrorCard title="Decentralized Network" error={metricsError ?? geoDataError}/>
+        {:else}
+          <DecentralizedNetworkCard
+                  totalUniqueCountries={uniqueCountries.toFixed() ?? "N/A"}
+                  totalNodeCount={metrics.node_count ?? "N/A"}
+                  totalCpuCores={metrics.system_cpu_cores ?? "N/A"}
+                  totalSystemMemory={metrics.system_memory ?? "N/A"}
+                  totalDiskSpace={metrics.disk_space_total ?? "N/A"}
+                  totalProcess={metrics.total_process ?? "N/A"}
+                  usedDiskSpace={metrics.disk_space_used ?? "N/A"}
+                  usedSystemMemory={metrics.system_memory_used ?? "N/A"}
+          />
+        {/if}
+      </div>
+
+      <!-- AI (GPU) -->
+      <div class="col-span-12 md:col-span-6 xl:col-span-3 h-full">
+        {#if metricsError}
+          <ErrorCard title="AI" error={metricsError}/>
+        {:else}
+          <GpuCard
+                  totalGpu={metrics.gpu_total ?? "N/A"}
+                  totalMemory={metrics.gpu_memory ?? "N/A"}
+                  totalNvidiaGpu={metrics.gpu_nvidia_total ?? "N/A"}
+                  totalAmdGpu={metrics.gpu_amd_total ?? "N/A"}
+                  totalNvidiaMemory={metrics.gpu_nvidia_memory ?? "N/A"}
+                  totalAmdMemory={metrics.gpu_amd_memory ?? "N/A"}
+          />
+        {/if}
+      </div>
+
+      <!-- Web Services -->
+      <div class="col-span-12 md:col-span-6 xl:col-span-3 h-full">
+        {#if metricsError || cumsumMetricsError}
+          <ErrorCard title="Web Services" error={metricsError ?? cumsumMetricsError}/>
+        {:else}
+          <WebServiceCard
+                  totalWebServer={metrics.web_servers ?? "N/A"}
+                  totalRequestPerSec={metrics.web_requests_per_sec ?? "N/A"}
+                  totalRequests={cumsumMetrics.web_requests ?? "N/A"}
+          />
+        {/if}
+      </div>
+
+      <!-- Decentralized Websites -->
+      <div class="col-span-12 md:col-span-6 xl:col-span-3 h-full">
+        {#if metricsError || cumsumMetricsError}
+          <ErrorCard title="Decentralized Web Hosting" error={metricsError ?? cumsumMetricsError}/>
+        {:else}
+          <DecentralizedWebHosting
+                  totalWebsites={metrics.web_sites ?? "N/A"}
+                  totalRequests={cumsumMetrics.decentralized_web_requests ?? "N/A"}
+          />
+        {/if}
+      </div>
+
+      <!-- Kubernetes -->
+      <div class="col-span-12 md:col-span-6 xl:col-span-3 h-full">
+        {#if metricsError}
+          <ErrorCard title="Kubernetes Metrics" error={metricsError}/>
+        {:else}
+          <KubeCard
+                  totalNodes={metrics.kube_nodes ?? "N/A"}
+                  totalPods={metrics.kube_pods ?? "N/A"}
+                  totalMemory={metrics.kube_memory ?? "N/A"}
+          />
+        {/if}
+      </div>
+
+      <!-- Object Storage -->
+      <div class="col-span-12 md:col-span-6 xl:col-span-3 h-full">
+        {#if metricsError}
+          <ErrorCard title="Object Storage" error={metricsError}/>
+        {:else}
+          <ObjectStorageCard
+                  totalBuckets={metrics.minio_buckets ?? "N/A"}
+                  totalObjects={metrics.minio_total ?? "N/A"}
+                  usedStorage={metrics.minio_used ?? "N/A"}
+          />
+        {/if}
+      </div>
+
+      <!-- Network -->
+      <div class="col-span-12 md:col-span-6 xl:col-span-6 h-full">
+        {#if cumsumMetricsError}
+          <ErrorCard title="Network Metrics" error={cumsumMetricsError}/>
+        {:else}
+          <NetworkCard
+                  totalIpv4BandwidthReceived={cumsumMetrics.system_network_received ?? "N/A"}
+                  totalIpv4BandwidthSent={cumsumMetrics.system_network_sent ?? "N/A"}
+                  totalIpv4PacketReceived={cumsumMetrics.system_tcp_received ?? "N/A"}
+                  totalIpv4PacketSent={cumsumMetrics.system_tcp_sent ?? "N/A"}
+          />
+        {/if}
+      </div>
+    </Section>
+
   </div>
 </main>


### PR DESCRIPTION
This pull request reorganizes the `Economy` section in the `src/routes/+page.svelte` file by moving it above the `Infrastructure` section. The actual content and logic of the `Economy` section remain unchanged; only its placement in the UI layout has been updated to display economy-related metrics before infrastructure-related metrics.

Layout and UI structure changes:

* Moved the entire `Economy` section, including the `TokenomicsCard` and `BlockchainCard` components, to appear before the `Infrastructure` section in the page layout. [[1]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfR59-R97) [[2]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL161-L198)