### PR TITLE
fix: offsets

### DIFF
--- a/src/lib/config/offsets.ts
+++ b/src/lib/config/offsets.ts
@@ -2,7 +2,8 @@
 // Any work performed on these metrics BEFORE the mainnet launch date should NOT be counted.
 import {bigNumberLike} from "$lib/schemas/common";
 
+// Offsets from September 21 2025 00:00:00 UTC
 export const METRIC_OFFSETS: Partial<Record<string, string>> = {
-  total_mfx_burned: bigNumberLike.parse("135304300855749600000"),
-  locked_fees: bigNumberLike.parse("162936737"),
+  total_mfx_burned: bigNumberLike.parse("135304300855652060000"),
+  locked_fees: bigNumberLike.parse("156969458"),
 }


### PR DESCRIPTION
This pull request updates the offset values for two key metrics in the `METRIC_OFFSETS` configuration, ensuring they reflect the correct values from September 21, 2025. These offsets are used to exclude any work performed before the mainnet launch date.

Metric offset updates:

* Updated the `total_mfx_burned` offset value to a new, more precise amount in `METRIC_OFFSETS` (`src/lib/config/offsets.ts`).
* Updated the `locked_fees` offset value to a new, lower value in `METRIC_OFFSETS` (`src/lib/config/offsets.ts`).