### PR TITLE
ci: disable docker cache

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,6 +46,7 @@ jobs:
           context: .
           push: true
           tags: lifted/manifest-dashboard:${{ env.GIT_TAG }}
+          no-cache: true
 
       - name: Build and push Docker image
         if: github.ref == 'refs/heads/main'
@@ -54,3 +55,4 @@ jobs:
           context: .
           push: true
           tags: lifted/manifest-dashboard:${{ matrix.environment }}
+          no-cache: true


### PR DESCRIPTION
This pull request makes a minor update to the Docker build process in the `.github/workflows/docker.yml` file. The main change is the addition of the `no-cache: true` option to the Docker build steps, ensuring that images are built from scratch without using cached layers. This helps prevent issues caused by outdated dependencies or build artifacts.