### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,6 @@
 name: Build and Push Docker Image
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/manifest-network/manifest-dashboard/security/code-scanning/1](https://github.com/manifest-network/manifest-dashboard/security/code-scanning/1)

To address this issue, we should add a `permissions` block to the workflow, thereby explicitly defining the minimum necessary privileges for the GITHUB_TOKEN. In this workflow, the default privilege set of `contents: read` should suffice, as the workflow does not push changes or otherwise interact with repository resources in a write capacity. This `permissions` block should be inserted at the root of the workflow, just below the `name` key and before `on:`, so it applies to all jobs unless overridden. This simple edit will ensure the workflow adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
