### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/manifest-network/manifest-dashboard/security/code-scanning/2](https://github.com/manifest-network/manifest-dashboard/security/code-scanning/2)

To fix the issue, you should add a `permissions` key to the job (or workflow root) that sets the least privilege necessary. For most build workflows, `contents: read` is sufficient unless you are pushing code, creating releases, or performing other write operations which this workflow does not do. Since all steps simply build and upload artifacts but never need to write to the repository, adding `permissions: contents: read` at the job level or at the root of the workflow suffices. The best place to add this is at the job level under the `build` job (for future extensibility, unless you want all jobs to inherit these permissions).

Edit `.github/workflows/build.yml` and add:
```yaml
permissions:
  contents: read
```
Indented correctly under the `build:` job (on the line after `build:` and before `runs-on:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
