### PR TITLE
chore(deps): bump

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,22 +7,21 @@
       "dependencies": {
         "@fontsource/poppins": "5.2.7",
         "@fontsource/source-sans-pro": "5.2.5",
-        "@skeletonlabs/skeleton": "4.3.2",
-        "@skeletonlabs/skeleton-svelte": "4.3.2",
-        "@sveltejs/kit": "2.48.4",
+        "@skeletonlabs/skeleton": "4.5.1",
+        "@skeletonlabs/skeleton-svelte": "4.5.1",
+        "@sveltejs/kit": "2.49.0",
         "bignumber.js": "9.3.1",
         "carbon-icons-svelte": "13.6.0",
         "colorjs.io": "0.5.2",
         "d3": "7.9.0",
         "d3-geo": "3.1.1",
         "d3-quadtree": "3.0.1",
-        "layerchart": "2.0.0-next.42",
+        "layerchart": "2.0.0-next.43",
         "lodash": "4.17.21",
         "runed": "0.36.0",
-        "svelte-canvas": "2.0.2",
         "topojson-server": "3.0.1",
         "topojson-simplify": "3.0.3",
-        "zod": "4.1.12",
+        "zod": "4.1.13",
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "7.0.0",
@@ -31,24 +30,22 @@
         "@tailwindcss/vite": "4.1.17",
         "@types/d3-geo": "3.1.0",
         "@types/d3-quadtree": "3.0.6",
-        "@types/lodash": "4.17.20",
+        "@types/lodash": "4.17.21",
         "@types/topojson-client": "3.1.5",
         "@types/topojson-simplify": "3.0.3",
         "@types/topojson-specification": "1.0.5",
-        "svelte": "5.43.5",
-        "svelte-check": "4.3.3",
+        "svelte": "5.43.14",
+        "svelte-check": "4.3.4",
         "tailwindcss": "4.1.17",
         "typescript": "5.8.3",
-        "vite": "7.2.2",
+        "vite": "7.2.4",
       },
     },
   },
   "overrides": {
-    "zod": "4.1.12",
+    "zod": "4.1.13",
   },
   "packages": {
-    "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
-
     "@dagrejs/dagre": ["@dagrejs/dagre@1.1.5", "", { "dependencies": { "@dagrejs/graphlib": "2.2.4" } }, "sha512-Ghgrh08s12DCL5SeiR6AoyE80mQELTWhJBRmXfFoqDiFkR458vPEdgTbbjA0T+9ETNxUblnD0QW55tfdvi5pjQ=="],
 
     "@dagrejs/graphlib": ["@dagrejs/graphlib@2.2.4", "", {}, "sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw=="],
@@ -189,11 +186,11 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.52.5", "", { "os": "win32", "cpu": "x64" }, "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg=="],
 
-    "@skeletonlabs/skeleton": ["@skeletonlabs/skeleton@4.3.2", "", { "peerDependencies": { "tailwindcss": "^4.0.0" } }, "sha512-4/Zo5SAQTzdYFXDL5s5blfZ4PrucIc93VdyLpfryGxW9yHPEsOEoH9RhRLvBuFeK/UfVNyhvXb1OlGRLRXPisw=="],
+    "@skeletonlabs/skeleton": ["@skeletonlabs/skeleton@4.5.1", "", { "peerDependencies": { "tailwindcss": "^4.0.0" } }, "sha512-B2vjKh+4PTz7ulbKzWsXAhMKiJUkQ14/Gd/bxDVPUpAfJEyyf1MbC18dby7zgo2R/jOMmpQrwcQ8LVyE56xzbQ=="],
 
-    "@skeletonlabs/skeleton-common": ["@skeletonlabs/skeleton-common@4.3.2", "", {}, "sha512-ZrGhPwPnUHbJJc0t4f2OOPPBe4Q+N4PwYJzGt78dxIju3Jsccax6HshrN0J+bTj+mb5Hp9bRWZ2/j7mY+f+SkA=="],
+    "@skeletonlabs/skeleton-common": ["@skeletonlabs/skeleton-common@4.5.1", "", {}, "sha512-cnvT1/qha4DmYXhkAJEZB/GBm8l+FIDT4hhnSg6SEjTuiPVnga31cjQ53Qdy53j4BEIrXN15znDWkAYTLlN9PQ=="],
 
-    "@skeletonlabs/skeleton-svelte": ["@skeletonlabs/skeleton-svelte@4.3.2", "", { "dependencies": { "@internationalized/date": "3.10.0", "@skeletonlabs/skeleton-common": "4.3.2", "@zag-js/accordion": "1.27.1", "@zag-js/avatar": "1.27.1", "@zag-js/collapsible": "1.27.1", "@zag-js/collection": "1.27.1", "@zag-js/combobox": "1.27.1", "@zag-js/date-picker": "1.27.1", "@zag-js/dialog": "1.27.1", "@zag-js/file-upload": "1.27.1", "@zag-js/listbox": "1.27.1", "@zag-js/pagination": "1.27.1", "@zag-js/popover": "1.27.1", "@zag-js/progress": "1.27.1", "@zag-js/radio-group": "1.27.1", "@zag-js/rating-group": "1.27.1", "@zag-js/slider": "1.27.1", "@zag-js/svelte": "1.27.1", "@zag-js/switch": "1.27.1", "@zag-js/tabs": "1.27.1", "@zag-js/tags-input": "1.27.1", "@zag-js/toast": "1.27.1", "@zag-js/toggle-group": "1.27.1", "@zag-js/tooltip": "1.27.1", "@zag-js/tree-view": "1.27.1" }, "peerDependencies": { "svelte": "^5.29.0" } }, "sha512-oyNbC+WQ8bzcoiPVFNMe7O001IMa7J7GEEeNCtAZtiP3pRK36IM5ABLm//Wd9YcNHzZ8q8mWGtF9m6lUKmaA9A=="],
+    "@skeletonlabs/skeleton-svelte": ["@skeletonlabs/skeleton-svelte@4.5.1", "", { "dependencies": { "@internationalized/date": "3.10.0", "@skeletonlabs/skeleton-common": "4.5.1", "@zag-js/accordion": "1.29.1", "@zag-js/avatar": "1.29.1", "@zag-js/collapsible": "1.29.1", "@zag-js/collection": "1.29.1", "@zag-js/combobox": "1.29.1", "@zag-js/date-picker": "1.29.1", "@zag-js/dialog": "1.29.1", "@zag-js/file-upload": "1.29.1", "@zag-js/listbox": "1.29.1", "@zag-js/menu": "1.29.1", "@zag-js/pagination": "1.29.1", "@zag-js/popover": "1.29.1", "@zag-js/progress": "1.29.1", "@zag-js/radio-group": "1.29.1", "@zag-js/rating-group": "1.29.1", "@zag-js/slider": "1.29.1", "@zag-js/svelte": "1.29.1", "@zag-js/switch": "1.29.1", "@zag-js/tabs": "1.29.1", "@zag-js/tags-input": "1.29.1", "@zag-js/toast": "1.29.1", "@zag-js/toggle-group": "1.29.1", "@zag-js/tooltip": "1.29.1", "@zag-js/tree-view": "1.29.1" }, "peerDependencies": { "svelte": "^5.29.0" } }, "sha512-Md/wWe3KdHH8b/9h898kPbhXaoVd17depEEi8U/VnC8D7um6E5wXsPd2bpvCsKBDKw900ouLuOYCZoGzXP9AVQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
@@ -203,7 +200,7 @@
 
     "@sveltejs/adapter-node": ["@sveltejs/adapter-node@5.4.0", "", { "dependencies": { "@rollup/plugin-commonjs": "^28.0.1", "@rollup/plugin-json": "^6.1.0", "@rollup/plugin-node-resolve": "^16.0.0", "rollup": "^4.9.5" }, "peerDependencies": { "@sveltejs/kit": "^2.4.0" } }, "sha512-NMsrwGVPEn+J73zH83Uhss/hYYZN6zT3u31R3IHAn3MiKC3h8fjmIAhLfTSOeNHr5wPYfjjMg8E+1gyFgyrEcQ=="],
 
-    "@sveltejs/kit": ["@sveltejs/kit@2.48.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/cookie": "^0.6.0", "acorn": "^8.14.1", "cookie": "^0.6.0", "devalue": "^5.3.2", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "sade": "^1.8.1", "set-cookie-parser": "^2.6.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["@opentelemetry/api"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-TGFX1pZUt9qqY20Cv5NyYvy0iLWHf2jXi8s+eCGsig7jQMdwZWKUFMR6TbvFNhfDSUpc1sH/Y5EHv20g3HHA3g=="],
+    "@sveltejs/kit": ["@sveltejs/kit@2.49.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/cookie": "^0.6.0", "acorn": "^8.14.1", "cookie": "^0.6.0", "devalue": "^5.3.2", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "sade": "^1.8.1", "set-cookie-parser": "^2.6.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["@opentelemetry/api"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-oH8tXw7EZnie8FdOWYrF7Yn4IKrqTFHhXvl8YxXxbKwTMcD/5NNCryUSEXRk2ZR4ojnub0P8rNrsVGHXWqIDtA=="],
 
     "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@6.2.1", "", { "dependencies": { "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0", "debug": "^4.4.1", "deepmerge": "^4.3.1", "magic-string": "^0.30.17", "vitefu": "^1.1.1" }, "peerDependencies": { "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ=="],
 
@@ -251,7 +248,7 @@
 
     "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
-    "@types/lodash": ["@types/lodash@4.17.20", "", {}, "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA=="],
+    "@types/lodash": ["@types/lodash@4.17.21", "", {}, "sha512-FOvQ0YPD5NOfPgMzJihoT+Za5pdkDJWcbpuj1DjaKZIr/gxodQjY/uWEFlTNqW2ugXHUiL8lRQgw63dzKHZdeQ=="],
 
     "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
 
@@ -261,85 +258,89 @@
 
     "@types/topojson-specification": ["@types/topojson-specification@1.0.5", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ=="],
 
-    "@zag-js/accordion": ["@zag-js/accordion@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-c6Ny0M/I4gqhcemD7THNBIKiBXLgJnRLmT1oOSZdPmwWI8Y6HMS/As8DDV3hsyzV/X26dbZiuJtuylAepMN3bQ=="],
+    "@zag-js/accordion": ["@zag-js/accordion@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-3laCyoAsInYPooQU5+tgwxiejU25M20etHbbZ6FIql8VRhKemYakpLaVdcXoFQXpwnnsVfyRv88fHYse+eR8vQ=="],
 
-    "@zag-js/anatomy": ["@zag-js/anatomy@1.27.1", "", {}, "sha512-vAgZ9RFm9wSucTMpbV1ZY2soZ6ZHQ9JAMOkLy1EPkWyE7+68VxzDh8rKc3Gq3LAjowgF2yR8tIe05njP9KFRjg=="],
+    "@zag-js/anatomy": ["@zag-js/anatomy@1.29.1", "", {}, "sha512-Yq2E/32mwh4MxQ5jeP3NlweoqsO6Q2UFawyrCwyzbOUovbcoC74H4/2i/qjVlhpfEuVRRWDiqn31z/OWc4w3dw=="],
 
-    "@zag-js/aria-hidden": ["@zag-js/aria-hidden@1.27.1", "", { "dependencies": { "@zag-js/dom-query": "1.27.1" } }, "sha512-8ax2IG0jOJnvNMb20INgxa5OS7jvr14dxuc8vgaNR9a0yfWzIuINp/O0FrN+8GNzaJzGMODwqGb0I7AOOIOAbw=="],
+    "@zag-js/aria-hidden": ["@zag-js/aria-hidden@1.29.1", "", { "dependencies": { "@zag-js/dom-query": "1.29.1" } }, "sha512-Q8JRvyOjEplKv4xjrJvHvvaGCc/8wa29B7vxck1QBcLqtzSxI003WeFg7fYf4J9NxQmKuFx9iwoh/iD4JmLIbw=="],
 
-    "@zag-js/auto-resize": ["@zag-js/auto-resize@1.27.1", "", { "dependencies": { "@zag-js/dom-query": "1.27.1" } }, "sha512-1hfHePSLs2AcESHUTzZhizn6lCCUeqwsWB4MsJwUzEqpGoW7DOKfOy27mfX50YlU7ttJOjlpYJ+Fp2g5FnzWWA=="],
+    "@zag-js/auto-resize": ["@zag-js/auto-resize@1.29.1", "", { "dependencies": { "@zag-js/dom-query": "1.29.1" } }, "sha512-ZAUqd3Mj9J9/SoeAJw9QtWAQgyf/66I2mXfVBIQK5VpgeDzOZ+J75zOaKr1h0abVlvi001+fFBMDj7N8MmqgTA=="],
 
-    "@zag-js/avatar": ["@zag-js/avatar@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-HTxhl+06CefIQIDnFvEdazCe0To3HDeYx+KrJ7UdBGUgGHVQ/n3/767QdrtIS26h71rTV9q7dMEsmr4ttugn6w=="],
+    "@zag-js/avatar": ["@zag-js/avatar@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-dkL6kk4Q4BvhJ6gDF+lb6rpmLkbFahFbXHyekDWQ003Ud+uW+MR3jIqIPuNnrKeGxts8Cl5q7ieI3sCneTWXyg=="],
 
-    "@zag-js/collapsible": ["@zag-js/collapsible@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-y+jw3N9BiIRaCtUFgpIC+Da1Fxn+DgwXnPdt2Ufk7xwDinRcOfD6ueGY+jBEFbZvVlOYzf+wU3rCopeKFNIh2Q=="],
+    "@zag-js/collapsible": ["@zag-js/collapsible@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-g7iIMLHHYVnR729jZ7ZeQsldvpFcSUOeNAFyeFYhsWdAl+NoRhlNkeH5sAFxIT115s2FKJOOWEbPeu8xgVSgNg=="],
 
-    "@zag-js/collection": ["@zag-js/collection@1.27.1", "", { "dependencies": { "@zag-js/utils": "1.27.1" } }, "sha512-zcf2GIpsACn0RUpNJSpRmbWOLbuiqMkRgZP4+Ub2Wy6lsYKi3Fou2A9o6Sm6HuNYMLJYRvos0oEEktHNJsLNyw=="],
+    "@zag-js/collection": ["@zag-js/collection@1.29.1", "", { "dependencies": { "@zag-js/utils": "1.29.1" } }, "sha512-Yz1ElOm56as/IRRh9lW2eTndHeHBaxVNjS0cGTWFmrSOTdjY4+ilTcHTv3FtyUw5sZurChEgKmFs7oUbHm7RaA=="],
 
-    "@zag-js/combobox": ["@zag-js/combobox@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/aria-hidden": "1.27.1", "@zag-js/collection": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dismissable": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/popper": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-Q+fC5SQgsLNdZoaaG1TbSZbvgm5H/tjaAbOull2zyrQzoe20WLCTJgHCWmVm1X0u5mEKXVf8xISzys8a+LJxwg=="],
+    "@zag-js/combobox": ["@zag-js/combobox@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/aria-hidden": "1.29.1", "@zag-js/collection": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dismissable": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/popper": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-7w5XFjjk/kp/8kDbPe3rw4G/zTAKtH4H6e7xvl6Bo5kpEJw/aq7yt05o8tAa2WNqT+491aXiQePYqr5PkPpGgQ=="],
 
-    "@zag-js/core": ["@zag-js/core@1.27.1", "", { "dependencies": { "@zag-js/dom-query": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-C35SJO7O5fyzgk+mhTSRWiApz0QP2MngT/qgCrSEDHss0ESd1scQylpDK8LrKDGHyYObJLLJhOAoeHWKALBTPA=="],
+    "@zag-js/core": ["@zag-js/core@1.29.1", "", { "dependencies": { "@zag-js/dom-query": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-5Qw3VbLo+jqqyXrUon/LIqJT/+SGHwx5sI1/qseOZBqYj46oabM/WiEoRztFq+FDJuL9VeHnVD6WB683Si5qwg=="],
 
-    "@zag-js/date-picker": ["@zag-js/date-picker@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/date-utils": "1.27.1", "@zag-js/dismissable": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/live-region": "1.27.1", "@zag-js/popper": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" }, "peerDependencies": { "@internationalized/date": ">=3.0.0" } }, "sha512-Hf3C6p+rOa7kamvRCaa4iJZZhAQoT6CMnp7V1jy57ICwpiXMhZ78HlzVZBKWmNuZlzibwzx6okfodlidMp+Mhg=="],
+    "@zag-js/date-picker": ["@zag-js/date-picker@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/date-utils": "1.29.1", "@zag-js/dismissable": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/live-region": "1.29.1", "@zag-js/popper": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" }, "peerDependencies": { "@internationalized/date": ">=3.0.0" } }, "sha512-uus+kuZ+dEHfGYr3QukIkVzYB/skh2EWnlDk/3hOAEw8KSzi3GQzpRIJFfGWaVoFBGvXvLRf8Vj/4ufrfLSsoQ=="],
 
-    "@zag-js/date-utils": ["@zag-js/date-utils@1.27.1", "", { "peerDependencies": { "@internationalized/date": ">=3.0.0" } }, "sha512-0s5qZAv+ZDRtg1fv848yC/2lt8dqNVN3DpW+JmOFioR9Cp2y+aBd+Ae5Y5Zh13kPcRvwDNVJ+kaeBOTJ9756Wg=="],
+    "@zag-js/date-utils": ["@zag-js/date-utils@1.29.1", "", { "peerDependencies": { "@internationalized/date": ">=3.0.0" } }, "sha512-NLEMNs2tRxRoJsobqajwAb+zuhx69MuA1UA1SxJAoauM6p8MulX8bJ4aqd3ZDPKlkGQbXu6e62fuTRkbjJDRXw=="],
 
-    "@zag-js/dialog": ["@zag-js/dialog@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/aria-hidden": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dismissable": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/focus-trap": "1.27.1", "@zag-js/remove-scroll": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-FHRSqZaiFu60NMuNE+jdXFDgkapVBtaJG+ts4CHn9wKnyQYmao41Nin5ZEQI8DaLgzxkBAgwEwg33FQ5L+99mg=="],
+    "@zag-js/dialog": ["@zag-js/dialog@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/aria-hidden": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dismissable": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/focus-trap": "1.29.1", "@zag-js/remove-scroll": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-fDNgeXqpY576L/PtRQn08XscY1nrL4jBvpw9JGq/w/PWeicM7K+kM9gnoEBz5MB7W+bMR+11AJXz/iKGE1GBzA=="],
 
-    "@zag-js/dismissable": ["@zag-js/dismissable@1.27.1", "", { "dependencies": { "@zag-js/dom-query": "1.27.1", "@zag-js/interact-outside": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-EZ9xq47m50scGV8JHYTAIL1DjnoFYChBC68cE9XNsqZO2vOINdYAfzsH73otx/CQ6RkhSk7eymP4fIzZVtRTVw=="],
+    "@zag-js/dismissable": ["@zag-js/dismissable@1.29.1", "", { "dependencies": { "@zag-js/dom-query": "1.29.1", "@zag-js/interact-outside": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-4EsVsPudQ17KaInrLQdeZyU8apjzXinfPjgSNBR7CPMU60O0J/zV9mXbn4lwXEE5Hy35lXq8s4V+W6wD0CwbLg=="],
 
-    "@zag-js/dom-query": ["@zag-js/dom-query@1.27.1", "", { "dependencies": { "@zag-js/types": "1.27.1" } }, "sha512-+oyhPQ6of1zCCK8iTaxxQc2FMFEJz1mr+1571vaSRdoxG31GhNkq/QDfUvQQnRR+2HV9yNiFk4hcjCDGqdXDTQ=="],
+    "@zag-js/dom-query": ["@zag-js/dom-query@1.29.1", "", { "dependencies": { "@zag-js/types": "1.29.1" } }, "sha512-GGN+Kt/+J9eiPeEqU+PsRYoNoRdFTNYP2ENCCaBSeypCsaxaG4wo99nbsoBwJwhr/c8zeUmULErgrGGoSh0F1Q=="],
 
-    "@zag-js/file-upload": ["@zag-js/file-upload@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/file-utils": "1.27.1", "@zag-js/i18n-utils": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-xChLU5NGnHn/G+L4GDPkCOa8XWY/gHeBbvQAaHItFKTpVmjWwM8uZ6X/utcWuZmdmUU8j/YfWYmCGdyux58I9Q=="],
+    "@zag-js/file-upload": ["@zag-js/file-upload@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/file-utils": "1.29.1", "@zag-js/i18n-utils": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-n321mbdiE6yeUvfDr6sTKxQMJz/BHDvYJvyCaO+MirXdrD80iSop7u4/caekqBFcerxtXg4FcjpPl1fvCGHr+w=="],
 
-    "@zag-js/file-utils": ["@zag-js/file-utils@1.27.1", "", { "dependencies": { "@zag-js/i18n-utils": "1.27.1" } }, "sha512-Ov5gMd7qUGdWydfjmtq/sm+PEl0LdJr7G4VuLZz3b4pJYVDBMv3pEHRXJj5x+b4mgm5U82vncE/itg/1Z08wKA=="],
+    "@zag-js/file-utils": ["@zag-js/file-utils@1.29.1", "", { "dependencies": { "@zag-js/i18n-utils": "1.29.1" } }, "sha512-nS6549/SkqFldlheXWSMiT+4NMVyB9PMg1DII36JANjgfoceVN/jBM21a6u7CssdpNnSYwqnD4Ozjeqkb3ZO5Q=="],
 
-    "@zag-js/focus-trap": ["@zag-js/focus-trap@1.27.1", "", { "dependencies": { "@zag-js/dom-query": "1.27.1" } }, "sha512-dHjN8Cxx2q7GyxfLhx6/FZgHRwTz4JnKT0bQxP3PjWsBQM1bVbFIJCL3lRy4NYQ1rJ1DA0LSbTecqqlKv4DgUw=="],
+    "@zag-js/focus-trap": ["@zag-js/focus-trap@1.29.1", "", { "dependencies": { "@zag-js/dom-query": "1.29.1" } }, "sha512-dDp/nuptTp1OJbEjSkLPNy6DxOSfYHKX292uvBV80xyLZUQ4s38wi8VCOuywpgF607WYIRozHI5PB8kaoz0sWA=="],
 
-    "@zag-js/focus-visible": ["@zag-js/focus-visible@1.27.1", "", { "dependencies": { "@zag-js/dom-query": "1.27.1" } }, "sha512-KGQAoiEejkEi0NMS33Q8mc7kedB0Y4g8WyKNaVlMgnqCEpi39cHkszgyZEvX1SYWfv4+RezQGfYOKo0Y6ze4uQ=="],
+    "@zag-js/focus-visible": ["@zag-js/focus-visible@1.29.1", "", { "dependencies": { "@zag-js/dom-query": "1.29.1" } }, "sha512-3zkxNQ0Gx8Xp45y7tfwqZZfJWLYwZhf9rEeMJT49InR9egWqtHCw/RjOQGR/2vydrPv7mfa14ikY/Gql2AX4TQ=="],
 
-    "@zag-js/i18n-utils": ["@zag-js/i18n-utils@1.27.1", "", { "dependencies": { "@zag-js/dom-query": "1.27.1" } }, "sha512-dNP7ZMoKxCD8KOc3RPqBpj7mEr5qb2qix8o6AQHw2QMDdgMDj0E9y5ZaNHIzkpMyYmvURY5I+pwWfFricv/rHg=="],
+    "@zag-js/i18n-utils": ["@zag-js/i18n-utils@1.29.1", "", { "dependencies": { "@zag-js/dom-query": "1.29.1" } }, "sha512-c1N5evLLkQpGizPZ8HSek14gaOJgRr7/vlXwWlaC1aSaGrRjZmi/YMmuTThCP4nja/6zKPNg9NJMbuwi/o3UTw=="],
 
-    "@zag-js/interact-outside": ["@zag-js/interact-outside@1.27.1", "", { "dependencies": { "@zag-js/dom-query": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-MfZobJhDWSiS9SzF35FJd/R+/ksvwzgjXl51p1sjaqVQoTIfKAe/pK8Hcky7NWX9NsVx77x/YidJpb/Bwf3f6g=="],
+    "@zag-js/interact-outside": ["@zag-js/interact-outside@1.29.1", "", { "dependencies": { "@zag-js/dom-query": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-hqZYr+OcnW+egU8W297pVK+6YMa+HOyFA0GHF45+29cB+mmTnMPTRcrdqNDFKA+f+ABQl3RH32E1WZjkluJc6A=="],
 
-    "@zag-js/listbox": ["@zag-js/listbox@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/collection": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/focus-visible": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-qZhmdD4+Gjof21i5C0sthNz+fOylrFnKJR7HxROWOeD2vHuQi4gud5PdZubfm54p7w8huPU8RH+Aw7LsVpwQNA=="],
+    "@zag-js/listbox": ["@zag-js/listbox@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/collection": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/focus-visible": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-UShb0caYtLshSHIwnVWz9QOvzm6WDb5+uogNHObt+6ALk77TZfKDxl29jmQ6/14H9ErYHLVsA6akschIaBswUg=="],
 
-    "@zag-js/live-region": ["@zag-js/live-region@1.27.1", "", {}, "sha512-T5cMSazmWC9AYKHinJQPZSc2bnokF8zK8ly4NGApv6ExM6Mf5wQoH6sJIcv7dhRFfPUFVRndVdKHnWxZjTb8Og=="],
+    "@zag-js/live-region": ["@zag-js/live-region@1.29.1", "", {}, "sha512-6+e5BQdzj/nuIK4Uxr3Tv5tKR9X3wP8DbLZPhAVF78XYPamuO19NhRjV4ph6Sp3Jme9gjP8BbaPGyXN4D6lDhA=="],
 
-    "@zag-js/pagination": ["@zag-js/pagination@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-tg23cP07weOtjNeEqOqS3Ilic3ikaIYQ7s9wi/JjvKUPMS+bi/LZRM12cfLD1tIwSUYjjLkr/reTnrYU3s2lZQ=="],
+    "@zag-js/menu": ["@zag-js/menu@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dismissable": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/popper": "1.29.1", "@zag-js/rect-utils": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-+L/J+nHlw0N3vwDqGFm7KAu3sbC0l4OVPziTjInlvrliwFbmMX86g17sVKvD/Ke/yc3YvTtJt48AAhidK1EWtA=="],
 
-    "@zag-js/popover": ["@zag-js/popover@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/aria-hidden": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dismissable": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/focus-trap": "1.27.1", "@zag-js/popper": "1.27.1", "@zag-js/remove-scroll": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-HvzogYsWhA2eVavSDJKsA98jzU95r/bSc6SsutnMp32afqf6eo2cZDOMm29tjzP2RPmZFYMwXVrQ4VZB4mIhXw=="],
+    "@zag-js/pagination": ["@zag-js/pagination@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-7KKCdUKPQNK6VuroRfxmxpNcWpuAUy6ZFvMUnaYFFBmCB7FGkOUAO1yEsYuJ9diAZvfprqw+8xnL5g93Xx/RtQ=="],
 
-    "@zag-js/popper": ["@zag-js/popper@1.27.1", "", { "dependencies": { "@floating-ui/dom": "1.7.4", "@zag-js/dom-query": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-ac9YpcIvhd9+QDhm85E0BzPmjTuAWc/FRQOhG/EWKSUDvFZGNAcXLSVS6zxIWPEdY2vDG3Ri9jpCNv89bzzpoQ=="],
+    "@zag-js/popover": ["@zag-js/popover@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/aria-hidden": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dismissable": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/focus-trap": "1.29.1", "@zag-js/popper": "1.29.1", "@zag-js/remove-scroll": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-MQ83k6JmvnvbvExZUvytNDUFZN7e4HHMdpq9meT5z1K+D9HaQ+gatHNk76cvv0H+yO+q90DDs5OUQ4ulzK/u2A=="],
 
-    "@zag-js/progress": ["@zag-js/progress@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-mBat/fn7jhuZXg+UBZMAQv3uL9W/HoDcrzm606PNycD+QyHFe8J1kpzHr8hFUFtCTzSDzmd5kf9zP0hieVPQTQ=="],
+    "@zag-js/popper": ["@zag-js/popper@1.29.1", "", { "dependencies": { "@floating-ui/dom": "1.7.4", "@zag-js/dom-query": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-elVi8eWMMrmOvtv627cc3+1bAeKM1VIrB4enpd6ccponXcPosaSTXHMR+lSxy9uOWaHZ/GkqYs+fWzguUJznSA=="],
 
-    "@zag-js/radio-group": ["@zag-js/radio-group@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/focus-visible": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-P1IHUrXv9iMHwLNdcIRoW0DQGfJ2DoMREWOohy8Gdekoo4/+xOGbr9qi9++QN//HMLsbB1cnD7+7WqqEZU1Hkw=="],
+    "@zag-js/progress": ["@zag-js/progress@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-UxyfFl+7dKKIqVxbyDjlXnAQSQt5gx0tWP7pt3KWuz6PSdU23fpq1dgv4YYBl8rX5EjX81B9uykE3WP8TRsz2w=="],
 
-    "@zag-js/rating-group": ["@zag-js/rating-group@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-bjsWkUwMtlm0Jsajz4j14ULFEeYtGTShqPZvFuVDrEX8xSuZXujfxOdY0dphc0EreyjL1YjvYboAXvYsVbOaVw=="],
+    "@zag-js/radio-group": ["@zag-js/radio-group@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/focus-visible": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-KFgF+8T+0nT6igPdCGmpsU5KxVsJVIsseVuABl3/IY679FZog0wAitbCHu9j/QoZxuS/kXj1eD2SbG/+92eDLQ=="],
 
-    "@zag-js/remove-scroll": ["@zag-js/remove-scroll@1.27.1", "", { "dependencies": { "@zag-js/dom-query": "1.27.1" } }, "sha512-MOnQXzifbeEuW/XgDMbb76wbWdaq++DEwE6CLmMQZhAR4rJUNIYVhcOFVqBWwMcMIJkvK8ROZucTPxOPmTHz1Q=="],
+    "@zag-js/rating-group": ["@zag-js/rating-group@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-Vcqv9FvsxCGaIVlA9LucDiLbttLapyil8Jc8KpKLAODsj1FSVVwgK50AkJnLw7n7SRoD+zx8HTIB1txfT9AQiw=="],
 
-    "@zag-js/slider": ["@zag-js/slider@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-p6zyMLU6cBtubk5673q2wk9JqCHf0l8my7nWY16KWqLWd68IFBSp7wrOyTYa0ifZ9CvmZZSjdL/w2TFJ4SHVKQ=="],
+    "@zag-js/rect-utils": ["@zag-js/rect-utils@1.29.1", "", {}, "sha512-3gxfOQb6JlxSbhoX7ULax79gRA3mz9U7A9MduG0GAABgbIXp8SIawNMQBd+ZjfXjVOGeEoA8bEVvDsWnpQ5SIw=="],
 
-    "@zag-js/svelte": ["@zag-js/svelte@1.27.1", "", { "dependencies": { "@zag-js/core": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" }, "peerDependencies": { "svelte": ">=5" } }, "sha512-9SLF7v6OzP1hP5d6LpHoW02nxSJifNkimW1HwsPtnxy9y1n/QSu9rxMSiisdEzyfM0cM4sQ+XmdMzbwBb75wmg=="],
+    "@zag-js/remove-scroll": ["@zag-js/remove-scroll@1.29.1", "", { "dependencies": { "@zag-js/dom-query": "1.29.1" } }, "sha512-qv/Ipa0apWE20BMTGfvigSOgPn930fXRsdKvMMuJVzaamoGkubfcs1h3HkNG1g/IB1Bx4N7GwD6oWiCMaeHdlQ=="],
 
-    "@zag-js/switch": ["@zag-js/switch@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/focus-visible": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-IuYacFHlQsxkFCU8ABGjwhtvWARexAYS/BMQkD5W8s0cwNHR3uOLPGjrJhSkJqvx3ENpSTRRKqTwawXVeFg2BQ=="],
+    "@zag-js/slider": ["@zag-js/slider@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-BHT3GqM54TjnzuqJfVjcreDFfkXLQNKXBKdTRKQtOkSNsQ7M9Lci8UBHn4WcvQJN5RZ37zsc+Z7zHfHEe/1KSg=="],
 
-    "@zag-js/tabs": ["@zag-js/tabs@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-jI+frE9z+wVfoqYA/7Xxr+SWix3OmjpfA7+F8GK1XPdN8atD/uYRgE7CbqwPc24fhIO/xkl1sNKRv83HaCMjvw=="],
+    "@zag-js/svelte": ["@zag-js/svelte@1.29.1", "", { "dependencies": { "@zag-js/core": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" }, "peerDependencies": { "svelte": ">=5" } }, "sha512-tNqubDfknNWwFH6HYVvk+Ba1IWCC0t+GcURZCzFCfHK0/Jyn4f1pUoaEzRF8DvvYaztUzQpAiAkbmmxaAsKPaQ=="],
 
-    "@zag-js/tags-input": ["@zag-js/tags-input@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/auto-resize": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/interact-outside": "1.27.1", "@zag-js/live-region": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-+XUOwKFWfGwmJpl3hWK8kHq5IeuZUZaR1FgNzbO029ll3p5unBOGzEL51oCH1dpeuMY/FyXEssNLrvVgId6E3Q=="],
+    "@zag-js/switch": ["@zag-js/switch@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/focus-visible": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-/Ztm/QDAQBFDcERadobfDuJufXHCBqPh/Mmuau1OTeZ+6EfwRCsPOzHsPmKUpQHOqerMXkYvDbFkNHjS7pfAYg=="],
 
-    "@zag-js/toast": ["@zag-js/toast@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dismissable": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-XfVxYlMkV8K1inmSwF+VKXkEPG/fDZcpjlj2PfbrWQu2PSD5mrJakBi1FzKfcCybp/OOD0V9Nfki1AFkhKKEwg=="],
+    "@zag-js/tabs": ["@zag-js/tabs@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-aicopH3c9Nf+HiybboNPtpdL7iNue48BJn4buBm/6cJ+6Xw/rqHaPpodayS2JNWro7tVdT2erf5+My/sD96MUg=="],
 
-    "@zag-js/toggle-group": ["@zag-js/toggle-group@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-b6KOd9ZKkWIl1vAmNIkeKrxE/ikKS5aGoseNbyFrcSPW43DwFZD24EfVIQ72/afzdTttRga0VbY1JgaCXothFw=="],
+    "@zag-js/tags-input": ["@zag-js/tags-input@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/auto-resize": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/interact-outside": "1.29.1", "@zag-js/live-region": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-izj0IVpBIRKGvd/RlO5zhupmZIHhlH96hBSWNQ1jwETmJRFnsV8RihyQ4P5XzQ9pfFlQozff58YoffunHk2KsA=="],
 
-    "@zag-js/tooltip": ["@zag-js/tooltip@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/focus-visible": "1.27.1", "@zag-js/popper": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-RVMFFdqX7HaSoO4GEHikRzrScelwVMr+mbTfrCcGx1i/9AWf7YmNh1P9p3QMIkP2/9TB9FfQfqU7Flyz0qc3Iw=="],
+    "@zag-js/toast": ["@zag-js/toast@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dismissable": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-x3gTqe9bRcqEnfwCFlugFmde5n0sYqHw01zNrp38s9zi4OZ8zeUJLK1tF0JSmEWClXECjV25E3V4Fm1ECRgRsA=="],
 
-    "@zag-js/tree-view": ["@zag-js/tree-view@1.27.1", "", { "dependencies": { "@zag-js/anatomy": "1.27.1", "@zag-js/collection": "1.27.1", "@zag-js/core": "1.27.1", "@zag-js/dom-query": "1.27.1", "@zag-js/types": "1.27.1", "@zag-js/utils": "1.27.1" } }, "sha512-YrP/F1d93/fXKtrN1Uhmzv9i13o39cLPno8X0i7PWvPVUv7HH+RqM0JZVROOQqhCWNUvkv/klGuGw5StP/RJGQ=="],
+    "@zag-js/toggle-group": ["@zag-js/toggle-group@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-Yava/DsXl7zRN0zPjVw4NO9HBh3cFEIyW0GXcm6BCmBpoD3eLUktUHskeCAIxnErLhAcL5NxZwAmt4+FB60Nsw=="],
 
-    "@zag-js/types": ["@zag-js/types@1.27.1", "", { "dependencies": { "csstype": "3.1.3" } }, "sha512-t7AtcXElKEjvvRlC1gcDmKgtIeiOtCL3vWf8K8kq7nVhq29q7PHtXB5ywn+R+CWnqJOmIDezKZjC1emXZKF0OA=="],
+    "@zag-js/tooltip": ["@zag-js/tooltip@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/focus-visible": "1.29.1", "@zag-js/popper": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-oKtfLEPwoX1PERVknfQjBh6H6IQRMeQjF+cmyf7ix0vSbPjCMx7ZniyRzeujk/4McG9HISnhRvkQCReiBiDMiA=="],
 
-    "@zag-js/utils": ["@zag-js/utils@1.27.1", "", {}, "sha512-AHSd3VeiBvVoa8lAUe7YsCzk37X9zn2jKiYv13k5Ac+NnbYRbpWzZZZUfNGbFAsu5cSE4X1HUw38H1GTuBeWNQ=="],
+    "@zag-js/tree-view": ["@zag-js/tree-view@1.29.1", "", { "dependencies": { "@zag-js/anatomy": "1.29.1", "@zag-js/collection": "1.29.1", "@zag-js/core": "1.29.1", "@zag-js/dom-query": "1.29.1", "@zag-js/types": "1.29.1", "@zag-js/utils": "1.29.1" } }, "sha512-0QMKpVY5xXq6sLf4aYgIHUMbtnmuhOgkQLYkEqN3rVnEfZRIr7YeIlLtPPad+oY8VetHRTBe4EfM80yrFHviLQ=="],
+
+    "@zag-js/types": ["@zag-js/types@1.29.1", "", { "dependencies": { "csstype": "3.1.3" } }, "sha512-/TVhGOxfakEF0IGA9s9Z+5hhzB5PJhLiGsr+g+nj8B2cpZM4HMQGi1h5N2EDXzTTRVEADqCB9vHwL4nw9gsBIw=="],
+
+    "@zag-js/utils": ["@zag-js/utils@1.29.1", "", {}, "sha512-qxGlQPcNn9QeP/F/KynnP2aPPUhjfVM0FrEiTzRTnt62kF+aLJBoYmLzoSnU8WqUq7dW5El71POW6lYyI7WQkg=="],
 
     "acorn": ["acorn@8.14.1", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="],
 
@@ -348,8 +349,6 @@
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
-
-    "canvas-size": ["canvas-size@1.2.6", "", {}, "sha512-x2iVHOrZ5x9V0Hwx6kBz+Yxf/VCAII+jrD6WLjJbytJLozHq/oDJjEva432Os0eHxWMFR0vYlLJwTr6QxyxQqw=="],
 
     "carbon-icons-svelte": ["carbon-icons-svelte@13.6.0", "", {}, "sha512-ZH2GcXVN/U2kBGj9CSnoxrsrSZpT1mVrjrNQTMEiLJ88U4tpkh758q3arLVX5Ji80vLGS/zNJoELdBGJbx3fZw=="],
 
@@ -461,7 +460,7 @@
 
     "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
-    "fdir": ["fdir@6.4.5", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw=="],
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -470,8 +469,6 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
-
-    "hit-canvas": ["hit-canvas@0.2.3", "", {}, "sha512-B9g7xsqu+gOt1S0b/IwMuCrskumPX7jILDKAPP96iW8F3eJFU7v87+e8N4jOEstY2vcpJzsG1cmiMkiwaaEM3Q=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
@@ -487,7 +484,7 @@
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
-    "layerchart": ["layerchart@2.0.0-next.42", "", { "dependencies": { "@dagrejs/dagre": "^1.1.5", "@layerstack/svelte-actions": "1.0.1-next.14", "@layerstack/svelte-state": "0.1.0-next.19", "@layerstack/tailwind": "2.0.0-next.17", "@layerstack/utils": "2.0.0-next.14", "d3-array": "^3.2.4", "d3-color": "^3.1.0", "d3-delaunay": "^6.0.4", "d3-dsv": "^3.0.1", "d3-force": "^3.0.0", "d3-geo": "^3.1.1", "d3-geo-voronoi": "^2.1.0", "d3-hierarchy": "^3.1.2", "d3-interpolate": "^3.0.1", "d3-interpolate-path": "^2.3.0", "d3-path": "^3.1.0", "d3-quadtree": "^3.0.1", "d3-random": "^3.0.1", "d3-sankey": "^0.12.3", "d3-scale": "^4.0.2", "d3-scale-chromatic": "^3.1.0", "d3-shape": "^3.2.0", "d3-tile": "^1.0.0", "d3-time": "^3.1.0", "lodash-es": "^4.17.21", "memoize": "^10.1.0", "runed": "^0.31.1" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-vLMHaLaU5Glf7OG56cZiD/1Dt6qvYHxc9gbNTq2ypjs+3iGLekx//wvkvCAmx8mH/t6kx1fbmxwKpf+RrFkyew=="],
+    "layerchart": ["layerchart@2.0.0-next.43", "", { "dependencies": { "@dagrejs/dagre": "^1.1.5", "@layerstack/svelte-actions": "1.0.1-next.14", "@layerstack/svelte-state": "0.1.0-next.19", "@layerstack/tailwind": "2.0.0-next.17", "@layerstack/utils": "2.0.0-next.14", "d3-array": "^3.2.4", "d3-color": "^3.1.0", "d3-delaunay": "^6.0.4", "d3-dsv": "^3.0.1", "d3-force": "^3.0.0", "d3-geo": "^3.1.1", "d3-geo-voronoi": "^2.1.0", "d3-hierarchy": "^3.1.2", "d3-interpolate": "^3.0.1", "d3-interpolate-path": "^2.3.0", "d3-path": "^3.1.0", "d3-quadtree": "^3.0.1", "d3-random": "^3.0.1", "d3-sankey": "^0.12.3", "d3-scale": "^4.0.2", "d3-scale-chromatic": "^3.1.0", "d3-shape": "^3.2.0", "d3-tile": "^1.0.0", "d3-time": "^3.1.0", "lodash-es": "^4.17.21", "memoize": "^10.1.0", "runed": "^0.31.1" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-1Ywm38NdzHWKwgaAHq3EcqshIgsq+pylntSnVWAVazXUk/NsxPcxdpR3tMt3ySjWV0ZPBBgLs78sdVf7FTgd+g=="],
 
     "lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
 
@@ -567,11 +564,9 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "svelte": ["svelte@5.43.5", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "esm-env": "^1.2.1", "esrap": "^2.1.0", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-HQoZArIewxQVNedseDsgMgnRSC4XOXczxXLF9rOJaPIJkg58INOPUiL8aEtzqZIXNSZJyw8NmqObwg/voajiHQ=="],
+    "svelte": ["svelte@5.43.14", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "esm-env": "^1.2.1", "esrap": "^2.1.0", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-pHeUrp1A5S6RGaXhJB7PtYjL1VVjbVrJ2EfuAoPu9/1LeoMaJa/pcdCsCSb0gS4eUHAHnhCbUDxORZyvGK6kOQ=="],
 
-    "svelte-canvas": ["svelte-canvas@2.0.2", "", { "dependencies": { "canvas-size": "^1.2.6", "hit-canvas": "^0.2.3", "svelte": "^5.0.0" } }, "sha512-316P22Dt/+A6vW9mLzW4/DjMJ/H1B3r8R7n3SBe0kaq5hWWfZwdNJCBdS2myvjs7y5c9meHxo4d+Ipsz2Rbcqw=="],
-
-    "svelte-check": ["svelte-check@4.3.3", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-RYP0bEwenDXzfv0P1sKAwjZSlaRyqBn0Fz1TVni58lqyEiqgwztTpmodJrGzP6ZT2aHl4MbTvWP6gbmQ3FOnBg=="],
+    "svelte-check": ["svelte-check@4.3.4", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-DVWvxhBrDsd+0hHWKfjP99lsSXASeOhHJYyuKOFYJcP7ThfSCKgjVarE8XfuMWpS5JV3AlDf+iK1YGGo2TACdw=="],
 
     "tailwind-merge": ["tailwind-merge@3.3.1", "", {}, "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g=="],
 
@@ -593,13 +588,13 @@
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
-    "vite": ["vite@7.2.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ=="],
+    "vite": ["vite@7.2.4", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w=="],
 
     "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
 
     "zimmerframe": ["zimmerframe@1.1.2", "", {}, "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w=="],
 
-    "zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
+    "zod": ["zod@4.1.13", "", {}, "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig=="],
 
     "@jridgewell/gen-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
@@ -615,7 +610,7 @@
 
     "@rollup/pluginutils/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
 
-    "@sveltejs/kit/magic-string": ["magic-string@0.30.19", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw=="],
+    "@sveltejs/kit/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "@tailwindcss/node/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -643,13 +638,7 @@
 
     "magic-string/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
-    "svelte/magic-string": ["magic-string@0.30.19", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw=="],
-
-    "svelte-canvas/svelte": ["svelte@5.27.0", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "esm-env": "^1.2.1", "esrap": "^1.4.6", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-Uai13Ydt1ZE+bUHme6b9U38PCYVNCqBRoBMkUKbFbKiD7kHWjdUUrklYAQZJxyKK81qII4mrBwe/YmvEMSlC9w=="],
-
-    "tinyglobby/fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
-
-    "vite/fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+    "svelte/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "@rollup/plugin-commonjs/is-reference/@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
@@ -660,11 +649,5 @@
     "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
-
-    "svelte-canvas/svelte/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
-
-    "svelte-canvas/svelte/@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
-
-    "svelte-canvas/svelte/esrap": ["esrap@1.4.6", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"gen-robots": "bun generate_robots.js"
 	},
 	"resolutions": {
-		"zod": "4.1.12"
+		"zod": "4.1.13"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "7.0.0",
@@ -24,34 +24,33 @@
 		"@tailwindcss/vite": "4.1.17",
 		"@types/d3-geo": "3.1.0",
 		"@types/d3-quadtree": "3.0.6",
-		"@types/lodash": "4.17.20",
+		"@types/lodash": "4.17.21",
 		"@types/topojson-client": "3.1.5",
 		"@types/topojson-simplify": "3.0.3",
 		"@types/topojson-specification": "1.0.5",
-		"svelte": "5.43.5",
-		"svelte-check": "4.3.3",
+		"svelte": "5.43.14",
+		"svelte-check": "4.3.4",
 		"tailwindcss": "4.1.17",
 		"typescript": "5.8.3",
-		"vite": "7.2.2"
+		"vite": "7.2.4"
 	},
 	"dependencies": {
 		"@fontsource/poppins": "5.2.7",
 		"@fontsource/source-sans-pro": "5.2.5",
-		"@skeletonlabs/skeleton": "4.3.2",
-		"@skeletonlabs/skeleton-svelte": "4.3.2",
-		"@sveltejs/kit": "2.48.4",
+		"@skeletonlabs/skeleton": "4.5.1",
+		"@skeletonlabs/skeleton-svelte": "4.5.1",
+		"@sveltejs/kit": "2.49.0",
 		"bignumber.js": "9.3.1",
 		"carbon-icons-svelte": "13.6.0",
 		"colorjs.io": "0.5.2",
 		"d3": "7.9.0",
 		"d3-geo": "3.1.1",
 		"d3-quadtree": "3.0.1",
-		"layerchart": "2.0.0-next.42",
+		"layerchart": "2.0.0-next.43",
 		"lodash": "4.17.21",
 		"runed": "0.36.0",
-		"svelte-canvas": "2.0.2",
 		"topojson-server": "3.0.1",
 		"topojson-simplify": "3.0.3",
-		"zod": "4.1.12"
+		"zod": "4.1.13"
 	}
 }


### PR DESCRIPTION
This pull request updates several dependencies in the `package.json` file to their latest patch or minor versions. These updates will help ensure better compatibility, security, and access to the latest features and bug fixes.

Dependency updates:

* Updated `zod` to version 4.1.13 in both `resolutions` and `dependencies`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L18-R18) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L27-R54)
* Bumped `@types/lodash` to 4.17.21, `svelte` to 5.43.14, `svelte-check` to 4.3.4, and `vite` to 7.2.4 in `devDependencies`.
* Upgraded `@skeletonlabs/skeleton` and `@skeletonlabs/skeleton-svelte` to 4.5.1, `@sveltejs/kit` to 2.49.0, and `layerchart` to 2.0.0-next.43 in `dependencies`.