### PR TITLE
mod: adding entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,13 +43,15 @@ FROM base AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
+ENV NETWORK=mainnet
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 svelte
 
 COPY --from=builder /app/build ./build
+COPY entrypoint.sh /app/entrypoint.sh
 
-RUN chown -R svelte:nodejs /app
+RUN chown -R svelte:nodejs /app ; chmod 755 /app/entrypoint.sh
 
 USER svelte
 
@@ -59,4 +61,4 @@ ENV ORIGIN="http://localhost:3000"
 ENV PORT=3000
 
 ENV HOSTNAME="0.0.0.0"
-CMD ["node", "build"]
+CMD ["/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash 
+
+perl -pi -e "s/NETWORK = \"mainnet\"/NETWORK = \"${NETWORK}\";/g"  ./build/server/chunks/createDataLoader*.js
+
+node build


### PR DESCRIPTION
This is a hack, rather than updating the JS code to use the env for network, we merely over right the hardcode.

Since we are building the node app as production, none of the debugging code is available. This script can make it so we can still modify some things at runtime.

