### PR TITLE
refactor: use mainnet/testnet rather than dev/prod

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        environment: [dev, prod]
+        environment: [testnet, mainnet]
     env:
       NODE_ENV: ${{ matrix.environment }}
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        environment: [dev, prod]
+        environment: [testnet, mainnet]
     environment: ${{ matrix.environment }}
     steps:
       - name: Checkout code
@@ -42,7 +42,7 @@ jobs:
         run: echo "GIT_TAG=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_ENV
 
       - name: Build and push with github release tag
-        if: matrix.environment == 'prod' && startsWith(github.ref, 'refs/tags/')
+        if: matrix.environment == 'mainnet' && startsWith(github.ref, 'refs/tags/')
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION

Ideally we will not mix names:  moving forward we should be using lean naming convention.  
example mainnet/testnet and manifest/many

fixes: reduces required regex, obviates env