### PR TITLE
feat(dashboard): rebrand web cards and hide the AI panel

### DIFF
--- a/src/lib/components/DecentralizedWebHosting.svelte
+++ b/src/lib/components/DecentralizedWebHosting.svelte
@@ -9,9 +9,9 @@
   }>();
 </script>
 
-<Card title="Decentralized Websites" href="/decentralized-website-details?interval=1 year">
+<Card title="Ghostcloud Deployments" href="/decentralized-website-details?interval=1 year">
   <div class="grid grid-cols-2 gap-x-4 gap-y-2">
-    <Metric value={formatNumber(totalWebsites)} label="Total Websites" />
-    <Metric value={formatLargeNumber(totalRequests)} label="Total Web Requests" />
+    <Metric value={formatNumber(totalWebsites)} label="Total Deployments" />
+    <Metric value={formatLargeNumber(totalRequests)} label="Total Deployment Requests" />
   </div>
 </Card>

--- a/src/lib/components/WebServiceCard.svelte
+++ b/src/lib/components/WebServiceCard.svelte
@@ -10,9 +10,9 @@
   }>();
 </script>
 
-<Card title="Web Services" href="/web-services-details?interval=1 year">
+<Card title="RPC Endpoint Mesh" href="/web-services-details?interval=1 year">
   <div class="grid grid-cols-2 gap-x-4 gap-y-2">
-    <Metric value={formatNumber(totalWebServer)} label="Total Web Servers" />
+    <Metric value={formatNumber(totalWebServer)} label="Total RPC Endpoints" />
     <Metric value={formatRoundNumber(totalRequestPerSec, 2)} label="Total Requests/Sec" />
     <Metric value={formatLargeNumber(totalRequests, 2)} label="Total Requests" />
   </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,7 +14,8 @@
   import DecentralizedWebHosting from "$lib/components/DecentralizedWebHosting.svelte";
   import KubeCard from "$lib/components/KubeCard.svelte";
   import ObjectStorageCard from "$lib/components/ObjectStorageCard.svelte";
-  import GpuCard from "$lib/components/GpuCard.svelte";
+  // Hidden: AI (GPU) panel — see the commented-out card block below.
+  // import GpuCard from "$lib/components/GpuCard.svelte";
   import WebServiceCard from "$lib/components/WebServiceCard.svelte";
   import NetworkCard from "$lib/components/NetworkCard.svelte";
   import ErrorCard from "$lib/components/ErrorCard.svelte";
@@ -131,7 +132,7 @@
         {/if}
       </div>
 
-      <!-- AI (GPU) -->
+      <!-- AI (GPU) - hidden
       <div class="col-span-12 md:col-span-6 xl:col-span-3 h-full">
         {#if metricsState.isInitialLoad}
           <CardSkeleton />
@@ -148,13 +149,14 @@
           }} />
         {/if}
       </div>
+      -->
 
-      <!-- Web Services -->
+      <!-- RPC Endpoint Mesh -->
       <div class="col-span-12 md:col-span-6 xl:col-span-3 h-full">
         {#if metricsState.isInitialLoad || cumsumMetricsState.isInitialLoad}
           <CardSkeleton />
         {:else if metricsError || cumsumMetricsError}
-          <ErrorCard title="Web Services" error={metricsError ?? cumsumMetricsError ?? ""} />
+          <ErrorCard title="RPC Endpoint Mesh" error={metricsError ?? cumsumMetricsError ?? ""} />
         {:else if metrics && cumsumMetrics}
           <WebServiceCard
             totalWebServer={metrics.web_servers ?? "N/A"}
@@ -164,12 +166,12 @@
         {/if}
       </div>
 
-      <!-- Decentralized Websites -->
+      <!-- Ghostcloud Deployments -->
       <div class="col-span-12 md:col-span-6 xl:col-span-3 h-full">
         {#if metricsState.isInitialLoad || cumsumMetricsState.isInitialLoad}
           <CardSkeleton />
         {:else if metricsError || cumsumMetricsError}
-          <ErrorCard title="Decentralized Web Hosting" error={metricsError ?? cumsumMetricsError ?? ""} />
+          <ErrorCard title="Ghostcloud Deployments" error={metricsError ?? cumsumMetricsError ?? ""} />
         {:else if metrics && cumsumMetrics}
           <DecentralizedWebHosting
             totalWebsites={metrics.web_sites ?? "N/A"}

--- a/src/routes/decentralized-website-details/config.ts
+++ b/src/routes/decentralized-website-details/config.ts
@@ -3,15 +3,15 @@ import {formatLargeNumber} from "$lib/utils/format";
 export const configs: ChartConfig[] = [
   {
     id: 'web_sites',
-    title: 'Total Websites',
-    yAxisTitle: '# of Websites',
+    title: 'Total Deployments',
+    yAxisTitle: '# of Deployments',
     category: 'gc',
     type: "common"
   },
   {
     id: 'decentralized_web_requests',
-    title: (latest) => `Total Web Requests: ${latest ? formatLargeNumber(latest.value) : "N/A"}`,
-    yAxisTitle: 'Web Requests',
+    title: (latest) => `Total Deployment Requests: ${latest ? formatLargeNumber(latest.value) : "N/A"}`,
+    yAxisTitle: 'Deployment Requests',
     category: 'gc',
     type: "cumsum",
     tooltipValueFormatter: (value: string) => formatLargeNumber(value),

--- a/src/routes/web-services-details/config.ts
+++ b/src/routes/web-services-details/config.ts
@@ -3,8 +3,8 @@ import {formatLargeNumber} from "$lib/utils/format";
 export const configs: ChartConfig[] = [
   {
     id: 'web_servers',
-    title: 'Total Web Servers',
-    yAxisTitle: '# of Web Servers',
+    title: 'Total RPC Endpoints',
+    yAxisTitle: '# of RPC Endpoints',
     category: 'web',
     type: "common"
   },


### PR DESCRIPTION
## What

Renames the two infrastructure cards to their new product names and removes the AI (GPU) panel from the home page.

| Before | After |
| --- | --- |
| `Decentralized Websites` | `Ghostcloud Deployments` |
| `Web Services` | `RPC Endpoint Mesh` |
| `Total Websites` | `Total Deployments` |

Adjacent labels brought in line so the cards and their detail pages read consistently:

| Before | After |
| --- | --- |
| `Total Web Requests` | `Total Deployment Requests` |
| `Total Web Servers` | `Total RPC Endpoints` |
| `# of Websites` (y-axis) | `# of Deployments` |
| `Web Requests` (y-axis) | `Deployment Requests` |
| `# of Web Servers` (y-axis) | `# of RPC Endpoints` |

The home-page `ErrorCard` for the Ghostcloud card was titled with the variant `Decentralized Web Hosting`; it now matches the card title.

Left verbatim (not part of the requested rename): `Total Requests`, `Total Requests/Sec`, `Web Requests/Sec`.

## AI panel

The AI (GPU) card block in `src/routes/+page.svelte` and its `GpuCard` import are commented out rather than deleted, so the panel is a two-line uncomment to restore. `/gpu-details` remains reachable by direct URL and stays in the sitemap.

## Scope

Display strings only. Routes (`/decentralized-website-details`, `/web-services-details`), component filenames, prop names, and the API metric ids (`web_sites`, `web_servers`) are unchanged — existing URLs and bookmarks keep working.

## Verification

- `bun run check` — 1617 files, 0 errors, 0 warnings
- `bun run build` — succeeds
- Home-page client bundle contains the new strings and no GPU card content (`GpuCard` is tree-shaken out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rzt6b3Tw87N8wC3mFaqPQ7
