### PR TITLE
fix(dashboard): label the chart "RPC Requests/Sec"

### DIFF
--- a/src/routes/web-services-details/config.ts
+++ b/src/routes/web-services-details/config.ts
@@ -10,8 +10,8 @@ export const configs: ChartConfig[] = [
   },
   {
     id: 'web_requests_per_sec',
-    title: 'Web Requests/Sec',
-    yAxisTitle: 'Web Requests/Sec',
+    title: 'RPC Requests/Sec',
+    yAxisTitle: 'RPC Requests/Sec',
     category: 'web',
     type: "common"
   },


### PR DESCRIPTION
The chart on `/web-services-details` still read **Web Requests/Sec** in both its title and y-axis label after the RPC Endpoint Mesh rebrand in #69. This renames it to **RPC Requests/Sec** so it matches the card it belongs to.

```diff
   {
     id: 'web_requests_per_sec',
-    title: 'Web Requests/Sec',
-    yAxisTitle: 'Web Requests/Sec',
+    title: 'RPC Requests/Sec',
+    yAxisTitle: 'RPC Requests/Sec',
```

Display strings only — the metric id (`web_requests_per_sec`), the route, and the config shape are unchanged, so the API contract and existing URLs are untouched. This was the last remaining "Web" label in `src/`.

`bun run check` reports 0 errors / 0 warnings, and `bun run test` passes 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rzt6b3Tw87N8wC3mFaqPQ7